### PR TITLE
feat: ドメインモデルの型定義を追加

### DIFF
--- a/src/domain/context.ts
+++ b/src/domain/context.ts
@@ -17,7 +17,7 @@ export type WinningConditions = {
   readonly rinshan: boolean // 嶺上
 };
 
-// ドラ（→ #6 ドラ選択）。赤ドラは各牌の isRed で表す。
+// ドラ（→ #6 ドラ選択）。赤ドラは各牌の isRedDora で表す。
 export type Dora = {
   readonly indicators: readonly Tile[]
   readonly uraIndicators: readonly Tile[]

--- a/src/domain/context.ts
+++ b/src/domain/context.ts
@@ -1,0 +1,32 @@
+// 和了条件（ツモ/ロン・場風/自風・和了条件フラグ・ドラ）のドメイン型
+
+import {
+  type Tile, type Wind
+} from './tile.ts';
+
+export type WinType = 'ron' | 'tsumo';
+
+// 和了条件フラグ（→ #5 条件選択）。ツモ・場風・自風は別フィールドで持つ。
+export type WinningConditions = {
+  readonly chankan: boolean // 槍槓
+  readonly doubleRiichi: boolean // ダブリー
+  readonly haitei: boolean // 海底
+  readonly houtei: boolean // 河底
+  readonly ippatsu: boolean // 一発
+  readonly riichi: boolean // リーチ
+  readonly rinshan: boolean // 嶺上
+};
+
+// ドラ（→ #6 ドラ選択）。赤ドラは各牌の isRed で表す。
+export type Dora = {
+  readonly indicators: readonly Tile[]
+  readonly uraIndicators: readonly Tile[]
+};
+
+export type WinningContext = {
+  readonly conditions: WinningConditions
+  readonly dora: Dora
+  readonly roundWind: Wind
+  readonly seatWind: Wind
+  readonly winType: WinType
+};

--- a/src/domain/hand.ts
+++ b/src/domain/hand.ts
@@ -4,8 +4,9 @@ import {
   type Tile
 } from './tile.ts';
 
-// ankan: 暗槓 / minkan: 明槓 / pon: ポン / chi: チー
-export type FuroType = 'ankan' | 'chi' | 'minkan' | 'pon';
+// ankan: 暗槓 / daiminkan: 大明槓 / kakan: 加槓 / pon: ポン / chi: チー
+// 槓は符・槍槓(#17)の判定で3系統を区別する必要があるため、明槓は大明槓と加槓に分ける。
+export type FuroType = 'ankan' | 'chi' | 'daiminkan' | 'kakan' | 'pon';
 
 // 鳴き元（上家・対面・下家）。暗槓は鳴き元が無いため null。
 export type CalledFrom = 'kamicha' | 'shimocha' | 'toimen';
@@ -17,6 +18,7 @@ export type Furo = {
 };
 
 export type Hand = {
+  // 門前の手牌。和了牌（winningTile）・副露（furo）は含めない。
   readonly concealed: readonly Tile[]
   readonly furo: readonly Furo[]
   readonly winningTile: Tile

--- a/src/domain/hand.ts
+++ b/src/domain/hand.ts
@@ -1,0 +1,23 @@
+// 手牌（純手牌・副露・和了牌）のドメイン型
+
+import {
+  type Tile
+} from './tile.ts';
+
+// ankan: 暗槓 / minkan: 明槓 / pon: ポン / chi: チー
+export type FuroType = 'ankan' | 'chi' | 'minkan' | 'pon';
+
+// 鳴き元（上家・対面・下家）。暗槓は鳴き元が無いため null。
+export type CalledFrom = 'kamicha' | 'shimocha' | 'toimen';
+
+export type Furo = {
+  readonly calledFrom: CalledFrom | null
+  readonly tiles: readonly Tile[]
+  readonly type: FuroType
+};
+
+export type Hand = {
+  readonly concealed: readonly Tile[]
+  readonly furo: readonly Furo[]
+  readonly winningTile: Tile
+};

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,0 +1,6 @@
+// ドメインモデルのバレル（再エクスポート）
+
+export * from './context.ts';
+export * from './hand.ts';
+export * from './mentsu.ts';
+export * from './tile.ts';

--- a/src/domain/mentsu.ts
+++ b/src/domain/mentsu.ts
@@ -1,0 +1,14 @@
+// 面子（順子・刻子・槓子・雀頭）のドメイン型
+
+import {
+  type Tile
+} from './tile.ts';
+
+// shuntsu: 順子 / kotsu: 刻子 / kantsu: 槓子 / pair: 雀頭
+export type MentsuType = 'kantsu' | 'kotsu' | 'pair' | 'shuntsu';
+
+export type Mentsu = {
+  readonly isOpen: boolean
+  readonly tiles: readonly Tile[]
+  readonly type: MentsuType
+};

--- a/src/domain/mentsu.ts
+++ b/src/domain/mentsu.ts
@@ -7,7 +7,14 @@ import {
 // shuntsu: 順子 / kotsu: 刻子 / kantsu: 槓子 / pair: 雀頭
 export type MentsuType = 'kantsu' | 'kotsu' | 'pair' | 'shuntsu';
 
+// 待ち形（符計算で使用。面子分解 #16 で判定）。
+// kanchan: 嵌張 / penchan: 辺張 / ryanmen: 両面 / shanpon: 双碰 / tanki: 単騎
+export type WaitType = 'kanchan' | 'penchan' | 'ryanmen' | 'shanpon' | 'tanki';
+
 export type Mentsu = {
+  // 明＝副露またはロンで完成した面子、暗＝門前で完成した面子。
+  // 明暗の最終確定（特にロンで完成した刻子は明刻扱い）は面子分解（#16）で行う。
+  // 4面子1雀頭＋待ち＋アガリ位置をまとめた「面子分解の出力型」は #16 で定義する。
   readonly isOpen: boolean
   readonly tiles: readonly Tile[]
   readonly type: MentsuType

--- a/src/domain/tile.ts
+++ b/src/domain/tile.ts
@@ -1,0 +1,102 @@
+// 牌のドメイン型と基本ユーティリティ
+
+export type Suit = 'man' | 'pin' | 'sou';
+
+export type Rank = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+
+export type Wind = 'east' | 'north' | 'south' | 'west';
+
+export type Dragon = 'green' | 'red' | 'white';
+
+export type Honor = Dragon | Wind;
+
+// 数牌（萬子・筒子・索子）。isRed は赤ドラかどうか。
+export type SuitedTile = {
+  readonly isRed: boolean
+  readonly rank: Rank
+  readonly suit: Suit
+  readonly type: 'suited'
+};
+
+// 字牌（風牌・三元牌）。
+export type HonorTile = {
+  readonly honor: Honor
+  readonly type: 'honor'
+};
+
+export type Tile = HonorTile | SuitedTile;
+
+// --- コンストラクタ ---
+
+export const suitedTile = (suit: Suit, rank: Rank, isRed = false): SuitedTile => {
+  return {
+    isRed,
+    rank,
+    suit,
+    type: 'suited',
+  };
+};
+
+export const honorTile = (honor: Honor): HonorTile => {
+  return {
+    honor,
+    type: 'honor',
+  };
+};
+
+// --- 型ガード ---
+
+export const isSuited = (tile: Tile): tile is SuitedTile => {
+  return tile.type === 'suited';
+};
+
+export const isHonor = (tile: Tile): tile is HonorTile => {
+  return tile.type === 'honor';
+};
+
+// --- 比較・正規化 ---
+
+const SUIT_ORDER: Record<Suit, number> = {
+  man: 0,
+  pin: 1,
+  sou: 2,
+};
+
+const HONOR_ORDER: Record<Honor, number> = {
+  east: 0,
+  green: 5,
+  north: 3,
+  red: 6,
+  south: 1,
+  west: 2,
+  white: 4,
+};
+
+// 牌全体の並び順インデックス（数牌 → 字牌）。数牌は赤ドラを区別しない。
+const tileOrder = (tile: Tile): number => {
+  if (tile.type === 'suited') {
+    return SUIT_ORDER[tile.suit] * 9 + (tile.rank - 1);
+  }
+  return 27 + HONOR_ORDER[tile.honor];
+};
+
+// 赤ドラの有無を無視し、同じ種類の牌かどうかを判定する。
+export const tilesEqual = (a: Tile, b: Tile): boolean => {
+  if (a.type === 'suited' && b.type === 'suited') {
+    return a.suit === b.suit && a.rank === b.rank;
+  }
+  if (a.type === 'honor' && b.type === 'honor') {
+    return a.honor === b.honor;
+  }
+  return false;
+};
+
+export const compareTiles = (a: Tile, b: Tile): number => {
+  return tileOrder(a) - tileOrder(b);
+};
+
+export const sortTiles = (tiles: readonly Tile[]): Tile[] => {
+  return [
+    ...tiles
+  ].sort(compareTiles);
+};

--- a/src/domain/tile.ts
+++ b/src/domain/tile.ts
@@ -10,9 +10,10 @@ export type Dragon = 'green' | 'red' | 'white';
 
 export type Honor = Dragon | Wind;
 
-// 数牌（萬子・筒子・索子）。isRed は赤ドラかどうか。
+// 数牌（萬子・筒子・索子）。isRedDora は赤ドラ（赤五）かどうか。
+// 三元牌の Dragon 'red'（中）と区別するため、赤ドラのフラグは isRedDora とする。
 export type SuitedTile = {
-  readonly isRed: boolean
+  readonly isRedDora: boolean
   readonly rank: Rank
   readonly suit: Suit
   readonly type: 'suited'
@@ -28,9 +29,9 @@ export type Tile = HonorTile | SuitedTile;
 
 // --- コンストラクタ ---
 
-export const suitedTile = (suit: Suit, rank: Rank, isRed = false): SuitedTile => {
+export const suitedTile = (suit: Suit, rank: Rank, isRedDora = false): SuitedTile => {
   return {
-    isRed,
+    isRedDora,
     rank,
     suit,
     type: 'suited',


### PR DESCRIPTION
## 概要

UI・点数計算ロジックの両方が依存するドメインモデルの型を定義する（最初の土台）。

## 変更内容

`src/domain/` に型定義を追加:

- `tile.ts` — 牌（数牌 `SuitedTile` / 字牌 `HonorTile`、`Suit`/`Rank`/`Wind`/`Dragon`/`Honor`）。コンストラクタ・型ガード・比較/正規化（`compareTiles`/`sortTiles`/`tilesEqual`）。赤ドラは `isRed` で表現し、種類比較では無視する。
- `mentsu.ts` — 面子（順子/刻子/槓子/雀頭、明暗）。
- `hand.ts` — 手牌（純手牌 + 副露 `Furo` + 和了牌）。
- `context.ts` — 和了条件（ツモ/ロン・場風/自風・条件フラグ・ドラ）。
- `index.ts` — バレル。

## スコープ外

- ロジック本体（面子分解 #16 / 役判定 #17 / 符・点数算出 #15）。本 PR は型と最小ユーティリティのみ。

## 確認

- `yarn lint` / `yarn build`（tsc）ともにパス。

Closes #14
