### PR TITLE
feat: 符計算と点数統合（高点法）を追加

### DIFF
--- a/src/engine/calculateHandScore.test.ts
+++ b/src/engine/calculateHandScore.test.ts
@@ -1,0 +1,243 @@
+import {
+  describe, expect, it
+} from 'vitest';
+
+import {
+  type Dora,
+  type Hand,
+  honorTile,
+  type Rank,
+  type Suit,
+  suitedTile,
+  type Tile,
+  type Wind,
+  type WinningConditions,
+  type WinningContext,
+  type WinType
+} from '../domain/index.ts';
+import {
+  calculateHandScore
+} from './calculateHandScore.ts';
+
+const suited = (suit: Suit, ranks: string): Tile[] => {
+  return [
+    ...ranks
+  ].map((rank) => {
+    return suitedTile(suit,
+      Number(rank) as Rank);
+  });
+};
+
+const makeHand = (concealed: Tile[], winningTile: Tile, furo: Hand['furo'] = [
+]): Hand => {
+  return {
+    concealed,
+    furo,
+    winningTile,
+  };
+};
+
+const baseConditions: WinningConditions = {
+  chankan: false,
+  doubleRiichi: false,
+  haitei: false,
+  houtei: false,
+  ippatsu: false,
+  riichi: false,
+  rinshan: false,
+};
+
+type ContextOverride = {
+  conditions?: Partial<WinningConditions>
+  dora?: Dora
+  roundWind?: Wind
+  seatWind?: Wind
+  winType?: WinType
+};
+
+const context = (over: ContextOverride = {
+}): WinningContext => {
+  return {
+    conditions: {
+      ...baseConditions,
+      ...over.conditions,
+    },
+    dora: over.dora ?? {
+      indicators: [
+      ],
+      uraIndicators: [
+      ],
+    },
+    roundWind: over.roundWind ?? 'east',
+    seatWind: over.seatWind ?? 'south',
+    winType: over.winType ?? 'ron',
+  };
+};
+
+// 平和 + 断么九 になる門前手（雀頭 33s、両面待ち pin7）。
+const pinfuHand = (): Hand => {
+  return makeHand([
+    ...suited('man',
+      '234567'),
+    ...suited('pin',
+      '23456'),
+    ...suited('sou',
+      '33')
+  ],
+  suitedTile('pin',
+    7));
+};
+
+describe('calculateHandScore',
+  () => {
+    it('子 平和+断么九 ロン = 30符2翻 = 2000',
+      () => {
+        const result = calculateHandScore(pinfuHand(),
+          context());
+        expect(result).not.toBeNull();
+        expect(result?.han).toBe(2);
+        expect(result?.fu).toBe(30);
+        expect(result?.total).toBe(2000);
+      });
+
+    it('子 立直+門前ツモ+平和+断么九 = 20符4翻 = 1300/2600（計5200）',
+      () => {
+        const result = calculateHandScore(pinfuHand(),
+          context({
+            conditions: {
+              riichi: true,
+            },
+            winType: 'tsumo',
+          }));
+        expect(result?.fu).toBe(20);
+        expect(result?.han).toBe(4);
+        expect(result?.payments).toStrictEqual({
+          fromDealer: 2600,
+          fromNonDealer: 1300,
+          kind: 'tsumo',
+        });
+        expect(result?.total).toBe(5200);
+      });
+
+    it('親 平和+断么九 ロン = 30符2翻 = 2900',
+      () => {
+        const result = calculateHandScore(pinfuHand(),
+          context({
+            seatWind: 'east',
+          }));
+        expect(result?.total).toBe(2900);
+      });
+
+    it('七対子 子 ロン = 25符2翻 = 1600',
+      () => {
+        const hand = makeHand([
+          ...suited('man',
+            '1133557799'),
+          ...suited('pin',
+            '22'),
+          ...suited('pin',
+            '4')
+        ],
+        suitedTile('pin',
+          4));
+        const result = calculateHandScore(hand,
+          context());
+        expect(result?.fu).toBe(25);
+        expect(result?.han).toBe(2);
+        expect(result?.total).toBe(1600);
+      });
+
+    it('高点法: 七対子(1600)より二盃口(5200)を採用',
+      () => {
+        const hand = makeHand([
+          ...suited('man',
+            '112233'),
+          ...suited('pin',
+            '445566'),
+          ...suited('sou',
+            '7')
+        ],
+        suitedTile('sou',
+          7));
+        const result = calculateHandScore(hand,
+          context());
+        expect(result?.yaku.map((yaku) => {
+          return yaku.name;
+        })).toContain('二盃口');
+        expect(result?.total).toBe(5200);
+      });
+
+    it('役満 国士無双 子 ロン = 32000',
+      () => {
+        const hand = makeHand([
+          ...suited('man',
+            '19'),
+          ...suited('pin',
+            '19'),
+          ...suited('sou',
+            '19'),
+          honorTile('east'),
+          honorTile('south'),
+          honorTile('west'),
+          honorTile('north'),
+          honorTile('white'),
+          honorTile('green'),
+          honorTile('red')
+        ],
+        suitedTile('man',
+          1));
+        const result = calculateHandScore(hand,
+          context());
+        expect(result?.yakuman).toContain('国士無双');
+        expect(result?.total).toBe(32000);
+      });
+
+    it('役無し（鳴き・役牌なし・断么九不成立）は null',
+      () => {
+        const furo: Hand['furo'] = [
+          {
+            calledFrom: 'kamicha',
+            tiles: [
+              suitedTile('pin',
+                1),
+              suitedTile('pin',
+                2),
+              suitedTile('pin',
+                3)
+            ],
+            type: 'chi',
+          }
+        ];
+        const hand = makeHand([
+          ...suited('man',
+            '456789'),
+          ...suited('sou',
+            '234'),
+          ...suited('sou',
+            '9')
+        ],
+        suitedTile('sou',
+          9),
+        furo);
+        const result = calculateHandScore(hand,
+          context());
+        expect(result).toBeNull();
+      });
+
+    it('和了形でない手は null',
+      () => {
+        const hand = makeHand([
+          ...suited('man',
+            '234567'),
+          ...suited('pin',
+            '234568'),
+          ...suited('sou',
+            '9')
+        ],
+        suitedTile('sou',
+          9));
+        const result = calculateHandScore(hand,
+          context());
+        expect(result).toBeNull();
+      });
+  });

--- a/src/engine/calculateHandScore.ts
+++ b/src/engine/calculateHandScore.ts
@@ -1,0 +1,115 @@
+// 点数統合（高点法）[#22]
+//
+// 手牌 + 和了条件から最終得点を求める。面子分解（#16）→ 役判定（#17）→ 符計算 → 点数算出（#15）を繋ぎ、
+// 複数の分解のうち最も高い点になる解（高点法）を採用する。役満は 8000×倍数 で別計算。役無しは null。
+
+import {
+  decomposeHand
+} from '../decomposition/index.ts';
+import {
+  type Hand,
+  type WinningContext
+} from '../domain/index.ts';
+import {
+  calculateScore,
+  paymentsFromBase,
+  type ScorePayments
+} from '../score/index.ts';
+import {
+  buildYakuInput,
+  isMenzenHand,
+  judgeYaku,
+  type Yaku
+} from '../yaku/index.ts';
+import {
+  calculateFu
+} from './fu.ts';
+
+const YAKUMAN_BASE = 8000;
+
+export type HandScore = {
+  readonly fu: number // 役満時は 0
+  readonly han: number // 役満時は 0
+  readonly payments: ScorePayments
+  readonly total: number // 和了者の総得点
+  readonly yaku: readonly Yaku[] // 通常役（ドラ含む）。役満時は空。
+  readonly yakuman: readonly string[] // 役満名（要素数 = 倍数）
+};
+
+export const calculateHandScore = (hand: Hand, context: WinningContext): HandScore | null => {
+  const decompositions = decomposeHand(hand);
+  if (decompositions.length === 0) {
+    return null; // 和了形でない。
+  }
+
+  const isMenzen = isMenzenHand(hand);
+  const isDealer = context.seatWind === 'east'; // 親 = 東家
+
+  const candidates: HandScore[] = [
+  ];
+  for (const decomposition of decompositions) {
+    const yakuResult = judgeYaku(buildYakuInput(
+      hand,
+      decomposition,
+      context
+    ));
+
+    if (yakuResult.yakuman.length > 0) {
+      const base = YAKUMAN_BASE * yakuResult.yakuman.length;
+      const {
+        payments, total,
+      } = paymentsFromBase(
+        base,
+        isDealer,
+        context.winType
+      );
+      candidates.push({
+        fu: 0,
+        han: 0,
+        payments,
+        total,
+        yaku: [
+        ],
+        yakuman: yakuResult.yakuman,
+      });
+      continue;
+    }
+
+    if (yakuResult.han === 0) {
+      continue; // 役無し（ドラのみ等）は和了不成立。
+    }
+
+    const isPinfu = yakuResult.yaku.some((yaku) => {
+      return yaku.name === '平和';
+    });
+    const fu = calculateFu(
+      decomposition,
+      context,
+      isMenzen,
+      isPinfu
+    );
+    const score = calculateScore({
+      fu,
+      han: yakuResult.han,
+      isDealer,
+      winType: context.winType,
+    });
+    candidates.push({
+      fu: score.fu,
+      han: yakuResult.han,
+      payments: score.payments,
+      total: score.total,
+      yaku: yakuResult.yaku,
+      yakuman: [
+      ],
+    });
+  }
+
+  if (candidates.length === 0) {
+    return null; // 役無し。
+  }
+
+  return candidates.reduce((best, current) => {
+    return current.total > best.total ? current : best;
+  });
+};

--- a/src/engine/fu.test.ts
+++ b/src/engine/fu.test.ts
@@ -179,4 +179,30 @@ describe('calculateFu',
           true,
           false)).toBe(50);
       });
+
+    it('連風牌雀頭は +2（天鳳/M-League ルール、+4 ではない）',
+      () => {
+      // 副底20 + ツモ2 + 嵌張2 + 暗刻(中張)4 = 28。連風牌雀頭が +2 なら30、+4 なら32→40。
+        const hand = makeHand([
+          ...suited('man',
+            '222'),
+          ...suited('pin',
+            '13'),
+          ...suited('sou',
+            '234567'),
+          honorTile('east'),
+          honorTile('east')
+        ],
+        suitedTile('pin',
+          2));
+        const decomposition = decomposeHand(hand)[0];
+        expect(calculateFu(decomposition,
+          context({
+            roundWind: 'east',
+            seatWind: 'east',
+            winType: 'tsumo',
+          }),
+          true,
+          false)).toBe(30);
+      });
   });

--- a/src/engine/fu.test.ts
+++ b/src/engine/fu.test.ts
@@ -1,0 +1,182 @@
+import {
+  describe, expect, it
+} from 'vitest';
+
+import {
+  decomposeHand
+} from '../decomposition/index.ts';
+import {
+  type Dora,
+  type Hand,
+  honorTile,
+  type Rank,
+  type Suit,
+  suitedTile,
+  type Tile,
+  type Wind,
+  type WinningConditions,
+  type WinningContext,
+  type WinType
+} from '../domain/index.ts';
+import {
+  calculateFu
+} from './fu.ts';
+
+const suited = (suit: Suit, ranks: string): Tile[] => {
+  return [
+    ...ranks
+  ].map((rank) => {
+    return suitedTile(suit,
+      Number(rank) as Rank);
+  });
+};
+
+const makeHand = (concealed: Tile[], winningTile: Tile): Hand => {
+  return {
+    concealed,
+    furo: [
+    ],
+    winningTile,
+  };
+};
+
+const baseConditions: WinningConditions = {
+  chankan: false,
+  doubleRiichi: false,
+  haitei: false,
+  houtei: false,
+  ippatsu: false,
+  riichi: false,
+  rinshan: false,
+};
+
+type ContextOverride = {
+  conditions?: Partial<WinningConditions>
+  dora?: Dora
+  roundWind?: Wind
+  seatWind?: Wind
+  winType?: WinType
+};
+
+const context = (over: ContextOverride = {
+}): WinningContext => {
+  return {
+    conditions: {
+      ...baseConditions,
+      ...over.conditions,
+    },
+    dora: over.dora ?? {
+      indicators: [
+      ],
+      uraIndicators: [
+      ],
+    },
+    roundWind: over.roundWind ?? 'east',
+    seatWind: over.seatWind ?? 'south',
+    winType: over.winType ?? 'ron',
+  };
+};
+
+describe('calculateFu',
+  () => {
+    it('平和 ロン = 30符',
+      () => {
+        const hand = makeHand([
+          ...suited('man',
+            '234567'),
+          ...suited('pin',
+            '23456'),
+          ...suited('sou',
+            '33')
+        ],
+        suitedTile('pin',
+          7));
+        const decomposition = decomposeHand(hand)[0];
+        expect(calculateFu(decomposition,
+          context(),
+          true,
+          true)).toBe(30);
+      });
+
+    it('平和 ツモ = 20符',
+      () => {
+        const hand = makeHand([
+          ...suited('man',
+            '234567'),
+          ...suited('pin',
+            '23456'),
+          ...suited('sou',
+            '33')
+        ],
+        suitedTile('pin',
+          7));
+        const decomposition = decomposeHand(hand)[0];
+        expect(calculateFu(decomposition,
+          context({
+            winType: 'tsumo',
+          }),
+          true,
+          true)).toBe(20);
+      });
+
+    it('七対子 = 25符',
+      () => {
+        const hand = makeHand([
+          ...suited('man',
+            '1133557799'),
+          ...suited('pin',
+            '22'),
+          ...suited('pin',
+            '4')
+        ],
+        suitedTile('pin',
+          4));
+        const decomposition = decomposeHand(hand)[0];
+        expect(calculateFu(decomposition,
+          context(),
+          true,
+          false)).toBe(25);
+      });
+
+    it('単騎待ち 門前ロン = 20+10+2 = 40符',
+      () => {
+        const hand = makeHand([
+          ...suited('man',
+            '234567'),
+          ...suited('pin',
+            '234567'),
+          ...suited('sou',
+            '9')
+        ],
+        suitedTile('sou',
+          9));
+        const decomposition = decomposeHand(hand)[0];
+        expect(calculateFu(decomposition,
+          context(),
+          true,
+          false)).toBe(40);
+      });
+
+    it('対々和（暗刻3 + ロン明刻の字牌） 門前ロン = 50符',
+      () => {
+        const hand = makeHand([
+          ...suited('man',
+            '222555'),
+          ...suited('pin',
+            '888'),
+          honorTile('east'),
+          honorTile('east'),
+          ...suited('sou',
+            '99')
+        ],
+        honorTile('east'));
+        const decomposition = decomposeHand(hand)[0];
+        expect(calculateFu(decomposition,
+          context({
+            roundWind: 'east',
+            seatWind: 'south',
+          }),
+          true,
+          false)).toBe(50);
+      });
+  });

--- a/src/engine/fu.ts
+++ b/src/engine/fu.ts
@@ -1,0 +1,103 @@
+// 符計算 [#22]
+//
+// 1つの面子分解 + 和了条件から符を算出する。
+// 副底20 + 門前ロン10 + ツモ2（平和ツモ除く） + 待ち + 雀頭 + 面子の符 → 10符単位で切り上げ。
+// 平和ロン=30 / 平和ツモ=20、七対子=25、喰い平和形（鳴き平和形のロン）=30。
+
+import {
+  type HandDecomposition
+} from '../decomposition/index.ts';
+import {
+  type Honor,
+  isHonor,
+  isSuited,
+  type Mentsu,
+  type Tile,
+  type WinningContext
+} from '../domain/index.ts';
+
+const isTerminal = (tile: Tile): boolean => {
+  return isSuited(tile) && (tile.rank === 1 || tile.rank === 9);
+};
+
+const isYaochu = (tile: Tile): boolean => {
+  return isHonor(tile) || isTerminal(tile);
+};
+
+const isDragon = (honor: Honor): boolean => {
+  return honor === 'green' || honor === 'red' || honor === 'white';
+};
+
+const isYakuhaiTile = (tile: Tile, context: WinningContext): boolean => {
+  if (!isHonor(tile)) {
+    return false;
+  }
+  return isDragon(tile.honor) || tile.honor === context.seatWind || tile.honor === context.roundWind;
+};
+
+// 刻子・槓子の符。順子・雀頭は 0（雀頭の役牌符は別途加算）。
+const meldFu = (meld: Mentsu, isOpenForFu: boolean): number => {
+  const yaochu = isYaochu(meld.tiles[0]);
+  if (meld.type === 'kotsu') {
+    if (yaochu) {
+      return isOpenForFu ? 4 : 8;
+    }
+    return isOpenForFu ? 2 : 4;
+  }
+  if (meld.type === 'kantsu') {
+    if (yaochu) {
+      return isOpenForFu ? 16 : 32;
+    }
+    return isOpenForFu ? 8 : 16;
+  }
+  return 0;
+};
+
+export const calculateFu = (
+  decomposition: HandDecomposition,
+  context: WinningContext,
+  isMenzen: boolean,
+  isPinfu: boolean
+): number => {
+  if (decomposition.form === 'sevenPairs') {
+    return 25;
+  }
+  if (decomposition.form === 'kokushi') {
+    return 0; // 役満は符を使わない（点数化は別経路）。
+  }
+
+  let fu = 20; // 副底
+  if (isMenzen && context.winType === 'ron') {
+    fu += 10;
+  }
+  if (context.winType === 'tsumo' && !isPinfu) {
+    fu += 2;
+  }
+  if (decomposition.wait === 'kanchan' || decomposition.wait === 'penchan' || decomposition.wait === 'tanki') {
+    fu += 2;
+  }
+
+  const pair = decomposition.mentsu.find((meld) => {
+    return meld.type === 'pair';
+  });
+  if (pair !== undefined && isYakuhaiTile(pair.tiles[0],
+    context)) {
+    fu += 2;
+  }
+
+  decomposition.mentsu.forEach((meld, index) => {
+    // ロンで完成した刻子（双碰）は明刻として扱う。
+    const isRonCompleted = context.winType === 'ron'
+      && index === decomposition.winningMentsuIndex
+      && meld.type === 'kotsu';
+    fu += meldFu(meld,
+      meld.isOpen || isRonCompleted);
+  });
+
+  // 喰い平和形（鳴きで全順子・両面・非役牌雀頭になりロンで20符）は30符に繰り上げる。
+  if (!isPinfu && fu === 20) {
+    fu = 30;
+  }
+
+  return Math.ceil(fu / 10) * 10;
+};

--- a/src/engine/fu.ts
+++ b/src/engine/fu.ts
@@ -77,6 +77,7 @@ export const calculateFu = (
     fu += 2;
   }
 
+  // 役牌雀頭は +2。連風牌（自風かつ場風）も +2 とする（天鳳/M-League 準拠。+4 を採るルールもある）。
   const pair = decomposition.mentsu.find((meld) => {
     return meld.type === 'pair';
   });

--- a/src/engine/index.ts
+++ b/src/engine/index.ts
@@ -1,0 +1,4 @@
+// 点数計算エンジン（符計算 + 高点法統合）のバレル（再エクスポート）
+
+export * from './calculateHandScore.ts';
+export * from './fu.ts';

--- a/src/score/score.ts
+++ b/src/score/score.ts
@@ -115,6 +115,50 @@ const resolveBase = (han: number, roundedFu: number): BaseResolution => {
   };
 };
 
+export type ScorePaymentsResult = {
+  readonly payments: ScorePayments
+  readonly total: number
+};
+
+// 基本点から支払い内訳と総得点を求める。役満の点数化（#22）でも再利用する。
+export const paymentsFromBase = (
+  base: number,
+  isDealer: boolean,
+  winType: WinType
+): ScorePaymentsResult => {
+  if (winType === 'ron') {
+    const fromDiscarder = ceil100(base * (isDealer ? 6 : 4));
+    return {
+      payments: {
+        fromDiscarder,
+        kind: 'ron',
+      },
+      total: fromDiscarder,
+    };
+  }
+  if (isDealer) {
+    const fromEach = ceil100(base * 2);
+    return {
+      payments: {
+        fromDealer: null,
+        fromNonDealer: fromEach,
+        kind: 'tsumo',
+      },
+      total: fromEach * 3,
+    };
+  }
+  const fromDealer = ceil100(base * 2);
+  const fromNonDealer = ceil100(base);
+  return {
+    payments: {
+      fromDealer,
+      fromNonDealer,
+      kind: 'tsumo',
+    },
+    total: fromDealer + fromNonDealer * 2,
+  };
+};
+
 export const calculateScore = (input: ScoreInput): ScoreResult => {
   const {
     fu, han, isDealer, winType,
@@ -132,50 +176,19 @@ export const calculateScore = (input: ScoreInput): ScoreResult => {
     han,
     roundedFu
   );
-
-  if (winType === 'ron') {
-    const fromDiscarder = ceil100(base * (isDealer ? 6 : 4));
-    return {
-      base,
-      fu: roundedFu,
-      han,
-      limit,
-      payments: {
-        fromDiscarder,
-        kind: 'ron',
-      },
-      total: fromDiscarder,
-    };
-  }
-
-  if (isDealer) {
-    const fromEach = ceil100(base * 2);
-    return {
-      base,
-      fu: roundedFu,
-      han,
-      limit,
-      payments: {
-        fromDealer: null,
-        fromNonDealer: fromEach,
-        kind: 'tsumo',
-      },
-      total: fromEach * 3,
-    };
-  }
-
-  const fromDealer = ceil100(base * 2);
-  const fromNonDealer = ceil100(base);
+  const {
+    payments, total,
+  } = paymentsFromBase(
+    base,
+    isDealer,
+    winType
+  );
   return {
     base,
     fu: roundedFu,
     han,
     limit,
-    payments: {
-      fromDealer,
-      fromNonDealer,
-      kind: 'tsumo',
-    },
-    total: fromDealer + fromNonDealer * 2,
+    payments,
+    total,
   };
 };


### PR DESCRIPTION
## 概要

面子分解（#16）→ 役判定（#17）→ 符計算 → 点数算出（#15）を繋ぎ、手牌＋和了条件から最終得点を求める統合関数 `calculateHandScore` を実装する。点数計算エンジンの総仕上げ。

## 変更内容

- `src/engine/fu.ts` — `calculateFu`。
  - 副底20 + 門前ロン10 + ツモ2（平和ツモ除く）+ 待ち（嵌張/辺張/単騎+2）+ 雀頭（役牌+2）+ 面子符（明刻/暗刻/明槓/暗槓 × 中張/么九）→ 10符切り上げ。
  - **ロンで完成した刻子は明刻扱い**（`winningMentsuIndex` を利用）。平和ロン=30/平和ツモ=20、七対子=25、喰い平和形（鳴き平和形ロン）=30。
- `src/engine/calculateHandScore.ts` — `calculateHandScore(hand, context): HandScore | null`。
  - 各分解について 役判定→符→点数 を計算し、**最も高い点になる解を採用（高点法）**。
  - 役満は 8000×倍数 で別計算。役無し（ドラのみ等）・和了形でない手は `null`。
  - 親判定は `seatWind === 'east'`。
- `src/score/score.ts` — 基本点→支払いの `paymentsFromBase` を切り出し（役満点数化で再利用するためのリファクタ。`calculateScore` の挙動は不変）。

## 確認

- `yarn lint` / `yarn test`（70 passed）/ `yarn build` すべてパス。
- End-to-End で既知の点数と一致: 子平和断么九ロン=2000、子リーチツモ平和断么=5200、親=2900、七対子=1600、**高点法で七対子(1600)より二盃口(5200)を採用**、国士=32000。符計算は平和30/20・七対子25・単騎40・対々和(ロン明刻含む)50。

## これで完成すること

手牌＋条件 → 役・翻・符・点数 が `calculateHandScore` 1関数で取得可能に。以降はUI（#4〜#18）からこのエンジンに繋ぐフェーズ。

Closes #22
