### PR TITLE
feat: 最小UIで手牌入力から点数表示まで連携 (MVP)

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,0 +1,23 @@
+import {
+  renderToStaticMarkup
+} from 'react-dom/server';
+import {
+  describe, expect, it
+} from 'vitest';
+
+import App from './App.tsx';
+
+// ヘッドレスブラウザが無い環境向けの描画スモークテスト。
+// App が例外なく初期描画でき、主要要素が含まれることを確認する（操作の検証はブラウザで）。
+describe('App',
+  () => {
+    it('クラッシュせず初期表示する',
+      () => {
+        const html = renderToStaticMarkup(<App />);
+        expect(html).toContain('麻雀点数計算ツール');
+        expect(html).toContain('5萬');
+        expect(html).toContain('東');
+        expect(html).toContain('牌を選んでください');
+        expect(html).toContain('14 枚そろえると点数を表示します。');
+      });
+  });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,10 +13,8 @@ import {
   calculateHandScore, type HandScore
 } from './engine/index.ts';
 import {
-  ALL_TILES, tileFromKey, tileKey, tileLabel
+  addTileToHand, ALL_TILES, HAND_SIZE, tileFromKey, tileKey, tileLabel
 } from './lib/tiles.ts';
-
-const HAND_SIZE = 14;
 
 const NO_CONDITIONS: WinningConditions = {
   chankan: false,
@@ -88,12 +86,8 @@ const App = (): React.ReactNode => {
       return;
     }
     setHandTiles((prev) => {
-      return prev.length >= HAND_SIZE
-        ? prev
-        : [
-            ...prev,
-            tile
-          ];
+      return addTileToHand(prev,
+        tile);
     });
   },
   [
@@ -148,6 +142,21 @@ const App = (): React.ReactNode => {
   },
   [
   ]);
+
+  const tileCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const tile of handTiles) {
+      const key = tileKey(tile);
+      counts.set(key,
+        (counts.get(key) ?? 0) + 1);
+    }
+    return counts;
+  },
+  [
+    handTiles
+  ]);
+
+  const isHandFull = handTiles.length >= HAND_SIZE;
 
   const effectiveWinning = winningIndex ?? handTiles.length - 1;
 
@@ -210,11 +219,14 @@ const App = (): React.ReactNode => {
         </h2>
         <div className="flex flex-wrap gap-1">
           {ALL_TILES.map((tile) => {
+            const key = tileKey(tile);
+            const disabled = isHandFull || (tileCounts.get(key) ?? 0) >= 4;
             return (
               <button
-                className={tileButtonClass}
-                data-tile={tileKey(tile)}
-                key={tileKey(tile)}
+                className={`${tileButtonClass} ${disabled ? 'cursor-not-allowed opacity-40' : ''}`}
+                data-tile={key}
+                disabled={disabled}
+                key={key}
                 onClick={handlePick}
                 type="button"
               >

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,406 @@
-import React from 'react';
+import React, {
+  useCallback, useMemo, useState
+} from 'react';
 
-import './App.css';
+import {
+  type Hand,
+  type Tile,
+  type Wind,
+  type WinningConditions,
+  type WinType
+} from './domain/index.ts';
+import {
+  calculateHandScore, type HandScore
+} from './engine/index.ts';
+import {
+  ALL_TILES, tileFromKey, tileKey, tileLabel
+} from './lib/tiles.ts';
+
+const HAND_SIZE = 14;
+
+const NO_CONDITIONS: WinningConditions = {
+  chankan: false,
+  doubleRiichi: false,
+  haitei: false,
+  houtei: false,
+  ippatsu: false,
+  riichi: false,
+  rinshan: false,
+};
+
+type WindOption = {
+  readonly label: string
+  readonly value: Wind
+};
+
+const WINDS: readonly WindOption[] = [
+  {
+    label: '東',
+    value: 'east',
+  },
+  {
+    label: '南',
+    value: 'south',
+  },
+  {
+    label: '西',
+    value: 'west',
+  },
+  {
+    label: '北',
+    value: 'north',
+  }
+];
+
+const tileButtonClass = 'min-w-9 rounded border border-stone-300 bg-white px-2 py-1 '
+  + 'text-lg hover:bg-amber-100 active:bg-amber-200';
 
 const App = (): React.ReactNode => {
+  const [
+    handTiles,
+    setHandTiles
+  ] = useState<Tile[]>([
+  ]);
+  const [
+    winningIndex,
+    setWinningIndex
+  ] = useState<null | number>(null);
+  const [
+    winType,
+    setWinType
+  ] = useState<WinType>('ron');
+  const [
+    roundWind,
+    setRoundWind
+  ] = useState<Wind>('east');
+  const [
+    seatWind,
+    setSeatWind
+  ] = useState<Wind>('east');
+  const [
+    riichi,
+    setRiichi
+  ] = useState(false);
+
+  const handlePick = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    const tile = tileFromKey(event.currentTarget.dataset.tile ?? '');
+    if (tile === undefined) {
+      return;
+    }
+    setHandTiles((prev) => {
+      return prev.length >= HAND_SIZE
+        ? prev
+        : [
+            ...prev,
+            tile
+          ];
+    });
+  },
+  [
+  ]);
+
+  const handleRemove = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    const index = Number(event.currentTarget.dataset.index);
+    setHandTiles((prev) => {
+      return prev.filter((_, i) => {
+        return i !== index;
+      });
+    });
+    setWinningIndex(null);
+  },
+  [
+  ]);
+
+  const handleSetWinning = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    setWinningIndex(Number(event.currentTarget.dataset.index));
+  },
+  [
+  ]);
+
+  const handleClear = useCallback(() => {
+    setHandTiles([
+    ]);
+    setWinningIndex(null);
+  },
+  [
+  ]);
+
+  const handleWinType = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
+    setWinType(event.target.value as WinType);
+  },
+  [
+  ]);
+
+  const handleRoundWind = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
+    setRoundWind(event.target.value as Wind);
+  },
+  [
+  ]);
+
+  const handleSeatWind = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
+    setSeatWind(event.target.value as Wind);
+  },
+  [
+  ]);
+
+  const handleRiichi = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    setRiichi(event.target.checked);
+  },
+  [
+  ]);
+
+  const effectiveWinning = winningIndex ?? handTiles.length - 1;
+
+  const score = useMemo<HandScore | null | undefined>(() => {
+    if (handTiles.length !== HAND_SIZE) {
+      return undefined;
+    }
+    if (effectiveWinning < 0 || effectiveWinning >= HAND_SIZE) {
+      return undefined;
+    }
+    const winningTile = handTiles[effectiveWinning];
+    const concealed = handTiles.filter((_, i) => {
+      return i !== effectiveWinning;
+    });
+    const hand: Hand = {
+      concealed,
+      furo: [
+      ],
+      winningTile,
+    };
+    return calculateHandScore(hand,
+      {
+        conditions: {
+          ...NO_CONDITIONS,
+          riichi,
+        },
+        dora: {
+          indicators: [
+          ],
+          uraIndicators: [
+          ],
+        },
+        roundWind,
+        seatWind,
+        winType,
+      });
+  },
+  [
+    handTiles,
+    effectiveWinning,
+    riichi,
+    roundWind,
+    seatWind,
+    winType
+  ]);
+
   return (
-    <>
-      <h1>
+    <div className="mx-auto max-w-3xl space-y-6 p-4">
+      <h1 className="text-2xl font-bold">
         麻雀点数計算ツール
       </h1>
-    </>
+
+      <section className="space-y-2">
+        <h2 className="font-semibold">
+          牌を選ぶ（
+          {handTiles.length}
+          /
+          {HAND_SIZE}
+          ）
+        </h2>
+        <div className="flex flex-wrap gap-1">
+          {ALL_TILES.map((tile) => {
+            return (
+              <button
+                className={tileButtonClass}
+                data-tile={tileKey(tile)}
+                key={tileKey(tile)}
+                onClick={handlePick}
+                type="button"
+              >
+                {tileLabel(tile)}
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="font-semibold">
+          手牌（クリックでアガリ牌に指定 / ×で削除）
+        </h2>
+        {handTiles.length === 0
+          ? (
+              <p className="text-stone-500">
+                牌を選んでください。
+              </p>
+            )
+          : (
+              <div className="flex flex-wrap gap-1">
+                {handTiles.map((tile, index) => {
+                  const isWinning = index === effectiveWinning;
+                  return (
+                    <span
+                      className="inline-flex items-center"
+                      key={`${tileKey(tile)}-${index}`}
+                    >
+                      <button
+                        className={`${tileButtonClass} ${isWinning ? 'ring-2 ring-rose-400' : ''}`}
+                        data-index={index}
+                        onClick={handleSetWinning}
+                        type="button"
+                      >
+                        {tileLabel(tile)}
+                      </button>
+                      <button
+                        className="px-1 text-stone-400 hover:text-rose-500"
+                        data-index={index}
+                        onClick={handleRemove}
+                        type="button"
+                      >
+                        ×
+                      </button>
+                    </span>
+                  );
+                })}
+              </div>
+            )}
+        <button
+          className="rounded border border-stone-300 px-3 py-1 text-sm hover:bg-stone-100"
+          onClick={handleClear}
+          type="button"
+        >
+          クリア
+        </button>
+      </section>
+
+      <section className="flex flex-wrap gap-4">
+        <label className="flex items-center gap-1">
+          和了
+          <select
+            className="rounded border border-stone-300 px-2 py-1"
+            onChange={handleWinType}
+            value={winType}
+          >
+            <option value="ron">
+              ロン
+            </option>
+            <option value="tsumo">
+              ツモ
+            </option>
+          </select>
+        </label>
+        <label className="flex items-center gap-1">
+          場風
+          <select
+            className="rounded border border-stone-300 px-2 py-1"
+            onChange={handleRoundWind}
+            value={roundWind}
+          >
+            {WINDS.map((wind) => {
+              return (
+                <option key={wind.value} value={wind.value}>
+                  {wind.label}
+                </option>
+              );
+            })}
+          </select>
+        </label>
+        <label className="flex items-center gap-1">
+          自風
+          <select
+            className="rounded border border-stone-300 px-2 py-1"
+            onChange={handleSeatWind}
+            value={seatWind}
+          >
+            {WINDS.map((wind) => {
+              return (
+                <option key={wind.value} value={wind.value}>
+                  {wind.label}
+                </option>
+              );
+            })}
+          </select>
+        </label>
+        <label className="flex items-center gap-1">
+          <input
+            checked={riichi}
+            onChange={handleRiichi}
+            type="checkbox"
+          />
+          リーチ
+        </label>
+      </section>
+
+      <section className="rounded border border-stone-300 p-4">
+        <h2 className="mb-2 font-semibold">
+          結果
+        </h2>
+        <ScoreView score={score} />
+      </section>
+    </div>
+  );
+};
+
+type ScoreViewProps = {
+  readonly score: HandScore | null | undefined
+};
+
+const ScoreView = ({
+  score,
+}: ScoreViewProps): React.ReactNode => {
+  if (score === undefined) {
+    return (
+      <p className="text-stone-500">
+        14 枚そろえると点数を表示します。
+      </p>
+    );
+  }
+  if (score === null) {
+    return (
+      <p className="text-rose-600">
+        役なし、または和了形ではありません。
+      </p>
+    );
+  }
+  const isYakuman = score.yakuman.length > 0;
+  return (
+    <div className="space-y-2">
+      <p className="text-3xl font-bold">
+        {score.total}
+        点
+      </p>
+      {isYakuman
+        ? (
+            <p className="font-semibold text-amber-700">
+              役満：
+              {score.yakuman.join('・')}
+            </p>
+          )
+        : (
+            <>
+              <p>
+                {score.han}
+                翻
+                {' '}
+                {score.fu}
+                符
+              </p>
+              <ul className="list-inside list-disc text-sm">
+                {score.yaku.map((yaku) => {
+                  return (
+                    <li key={yaku.name}>
+                      {yaku.name}
+                      {' '}
+                      {yaku.han}
+                      翻
+                    </li>
+                  );
+                })}
+              </ul>
+            </>
+          )}
+    </div>
   );
 };
 

--- a/src/lib/tiles.test.ts
+++ b/src/lib/tiles.test.ts
@@ -1,0 +1,86 @@
+import {
+  describe, expect, it
+} from 'vitest';
+
+import {
+  honorTile, suitedTile, type Tile
+} from '../domain/index.ts';
+import {
+  addTileToHand, HAND_SIZE
+} from './tiles.ts';
+
+describe('addTileToHand',
+  () => {
+    it('空の手牌に追加できる',
+      () => {
+        const result = addTileToHand([
+        ],
+        suitedTile('man',
+          1));
+        expect(result).toHaveLength(1);
+      });
+
+    it('同じ牌は4枚まで（5枚目は追加されない）',
+      () => {
+        const four: Tile[] = [
+          suitedTile('man',
+            1),
+          suitedTile('man',
+            1),
+          suitedTile('man',
+            1),
+          suitedTile('man',
+            1)
+        ];
+        const result = addTileToHand(four,
+          suitedTile('man',
+            1));
+        expect(result).toHaveLength(4);
+      });
+
+    it('赤ドラ違いでも同じ牌として4枚制限',
+      () => {
+        const four: Tile[] = [
+          suitedTile('pin',
+            5),
+          suitedTile('pin',
+            5),
+          suitedTile('pin',
+            5),
+          suitedTile('pin',
+            5,
+            true)
+        ];
+        const result = addTileToHand(four,
+          suitedTile('pin',
+            5));
+        expect(result).toHaveLength(4);
+      });
+
+    it('字牌も4枚まで',
+      () => {
+        const four: Tile[] = [
+          honorTile('east'),
+          honorTile('east'),
+          honorTile('east'),
+          honorTile('east')
+        ];
+        const result = addTileToHand(four,
+          honorTile('east'));
+        expect(result).toHaveLength(4);
+      });
+
+    it('手牌が HAND_SIZE 枚あるとそれ以上追加されない',
+      () => {
+        const full: Tile[] = Array.from({
+          length: HAND_SIZE,
+        },
+        (_, index) => {
+          return suitedTile('sou',
+            ((index % 9) + 1) as 1);
+        });
+        const result = addTileToHand(full,
+          honorTile('white'));
+        expect(result).toHaveLength(HAND_SIZE);
+      });
+  });

--- a/src/lib/tiles.ts
+++ b/src/lib/tiles.ts
@@ -7,8 +7,14 @@ import {
   type Rank,
   type Suit,
   suitedTile,
-  type Tile
+  type Tile,
+  tilesEqual
 } from '../domain/index.ts';
+
+// 和了形の総枚数（4面子1雀頭 = 13 + アガリ牌1）。
+export const HAND_SIZE = 14;
+
+const MAX_PER_KIND = 4;
 
 const SUIT_LABEL: Record<Suit, string> = {
   man: '萬',
@@ -85,4 +91,21 @@ const TILE_BY_KEY = new Map<string, Tile>(ALL_TILES.map((tile) => {
 
 export const tileFromKey = (key: string): Tile | undefined => {
   return TILE_BY_KEY.get(key);
+};
+
+// 牌を手牌に追加する。各牌は4枚まで、手牌は HAND_SIZE 枚まで。追加できない場合は元の内容を返す。
+export const addTileToHand = (tiles: readonly Tile[], tile: Tile): Tile[] => {
+  const sameCount = tiles.filter((current) => {
+    return tilesEqual(current,
+      tile);
+  }).length;
+  if (tiles.length >= HAND_SIZE || sameCount >= MAX_PER_KIND) {
+    return [
+      ...tiles
+    ];
+  }
+  return [
+    ...tiles,
+    tile
+  ];
 };

--- a/src/lib/tiles.ts
+++ b/src/lib/tiles.ts
@@ -1,0 +1,88 @@
+// UI 用の牌ヘルパー（表示ラベル・牌一覧・キー対応）。
+
+import {
+  type Honor,
+  honorTile,
+  isSuited,
+  type Rank,
+  type Suit,
+  suitedTile,
+  type Tile
+} from '../domain/index.ts';
+
+const SUIT_LABEL: Record<Suit, string> = {
+  man: '萬',
+  pin: '筒',
+  sou: '索',
+};
+
+const HONOR_LABEL: Record<Honor, string> = {
+  east: '東',
+  green: '發',
+  north: '北',
+  red: '中',
+  south: '南',
+  west: '西',
+  white: '白',
+};
+
+// 表示用ラベル（例: 5萬 / 東 / 白）。
+export const tileLabel = (tile: Tile): string => {
+  if (isSuited(tile)) {
+    return `${tile.rank}${SUIT_LABEL[tile.suit]}`;
+  }
+  return HONOR_LABEL[tile.honor];
+};
+
+// 識別キー（data 属性・React key 用。赤ドラは扱わない）。
+export const tileKey = (tile: Tile): string => {
+  if (isSuited(tile)) {
+    return `${tile.suit}-${tile.rank}`;
+  }
+  return `honor-${tile.honor}`;
+};
+
+const SUIT_ORDER: readonly Suit[] = [
+  'man',
+  'pin',
+  'sou'
+];
+
+const HONOR_ORDER: readonly Honor[] = [
+  'east',
+  'south',
+  'west',
+  'north',
+  'white',
+  'green',
+  'red'
+];
+
+const buildAllTiles = (): Tile[] => {
+  const tiles: Tile[] = [
+  ];
+  for (const suit of SUIT_ORDER) {
+    for (let rank = 1; rank <= 9; rank += 1) {
+      tiles.push(suitedTile(suit,
+        rank as Rank));
+    }
+  }
+  for (const honor of HONOR_ORDER) {
+    tiles.push(honorTile(honor));
+  }
+  return tiles;
+};
+
+// ピッカーに並べる 34 種（数牌 → 字牌）。
+export const ALL_TILES: readonly Tile[] = buildAllTiles();
+
+const TILE_BY_KEY = new Map<string, Tile>(ALL_TILES.map((tile) => {
+  return [
+    tileKey(tile),
+    tile
+  ];
+}));
+
+export const tileFromKey = (key: string): Tile | undefined => {
+  return TILE_BY_KEY.get(key);
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,7 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
   test: {
     include: [
-      'src/**/*.test.ts'
+      'src/**/*.test.{ts,tsx}'
     ],
   },
 });


### PR DESCRIPTION
## 概要

点数計算エンジン（#22 `calculateHandScore`）に繋いだ最小の動くUI（MVP）。「牌を選ぶ → 条件指定 → 点数が出る」を一画面で通す縦串。

## 変更内容

- `src/lib/tiles.ts` — UI用の牌ヘルパー（表示ラベル `5萬`/`東`、34種一覧 `ALL_TILES`、キー対応 `tileKey`/`tileFromKey`）。
- `src/App.tsx` — 計算画面。
  - 牌ピッカー（テキスト/CSS、34種）→ クリックで手牌に追加（最大14）。
  - 手牌表示：クリックでアガリ牌指定（赤枠）、×で削除、クリア。
  - 条件：ツモ/ロン・場風・自風・リーチ（MVPは門前のみ、副露・ドラは後続）。
  - 14枚そろうと `calculateHandScore` を呼び、役一覧・翻・符・点数を表示。役満・役なし・非和了形はメッセージ。
- `src/App.test.tsx` — 描画スモークテスト（`renderToStaticMarkup`、計72テスト）。`vitest.config.ts` の include を `.tsx` 対応に。

## 設計判断

- 状態は `useState`（MVPはライブラリ不要）。ESLint `react/jsx-no-bind` 対応のため、ハンドラは `useCallback` で安定参照にし、リストは `data-*` 属性 + 単一ハンドラで処理。
- 牌は素の Tailwind 表示（画像素材は #4）。shadcn/ui 採用は後続で検討。

## 確認

- `yarn lint` / `yarn test`（72 passed）/ `yarn build` パス。`yarn dev` は HTTP 200 で配信を確認。
- 本環境にヘッドレスブラウザが無いため自動の操作検証は不可。描画はスモークテストで担保、ロジックは71テストで担保。**ブラウザでの手動クリック確認を推奨**。

## 後続（既存issue）

#4 牌画像 / #3 手牌表示の作り込み / #5 条件の拡充 / #6 ドラ / #7 副露 / #18 結果表示の作り込み。

Closes #25
