### PR TITLE
feat: ドラ選択（表/裏ドラ表示牌・赤ドラ）を追加

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -18,6 +18,7 @@ describe('App',
         expect(html).toContain('5萬');
         expect(html).toContain('東');
         expect(html).toContain('牌を選んでください');
+        expect(html).toContain('ドラ表示牌（次の牌がドラ）');
         expect(html).toContain('14 枚そろえると点数を表示します。');
       });
   });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,7 +5,6 @@ import React, {
 import {
   type Hand,
   isSuited,
-  suitedTile,
   type Tile,
   type Wind,
   type WinningConditions,
@@ -15,7 +14,7 @@ import {
   calculateHandScore, type HandScore
 } from './engine/index.ts';
 import {
-  addTileToHand, ALL_TILES, HAND_SIZE, tileFromKey, tileKey, tileLabel
+  addTileToHand, ALL_TILES, HAND_SIZE, tileFromKey, tileKey, tileLabel, toggleRedFive
 } from './lib/tiles.ts';
 
 const NO_CONDITIONS: WinningConditions = {
@@ -157,18 +156,12 @@ const App = (): React.ReactNode => {
   [
   ]);
 
-  // 手牌の5を赤ドラに切り替える。
+  // 手牌の5を赤ドラに切り替える（同色の赤5は1枚まで）。
   const handleToggleRed = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
     const index = Number(event.currentTarget.dataset.index);
     setHandTiles((prev) => {
-      return prev.map((tile, i) => {
-        if (i !== index || !isSuited(tile)) {
-          return tile;
-        }
-        return suitedTile(tile.suit,
-          tile.rank,
-          !tile.isRedDora);
-      });
+      return toggleRedFive(prev,
+        index);
     });
   },
   [

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,8 @@ import React, {
 
 import {
   type Hand,
+  isSuited,
+  suitedTile,
   type Tile,
   type Wind,
   type WinningConditions,
@@ -53,6 +55,8 @@ const WINDS: readonly WindOption[] = [
 const tileButtonClass = 'min-w-9 rounded border border-stone-300 bg-white px-2 py-1 '
   + 'text-lg hover:bg-amber-100 active:bg-amber-200';
 
+const MAX_DORA = 5; // ドラ表示牌は最大5枚（4カン + 1）。
+
 const App = (): React.ReactNode => {
   const [
     handTiles,
@@ -79,6 +83,16 @@ const App = (): React.ReactNode => {
     riichi,
     setRiichi
   ] = useState(false);
+  const [
+    doraIndicators,
+    setDoraIndicators
+  ] = useState<Tile[]>([
+  ]);
+  const [
+    uraIndicators,
+    setUraIndicators
+  ] = useState<Tile[]>([
+  ]);
 
   const handlePick = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
     const tile = tileFromKey(event.currentTarget.dataset.tile ?? '');
@@ -143,6 +157,79 @@ const App = (): React.ReactNode => {
   [
   ]);
 
+  // 手牌の5を赤ドラに切り替える。
+  const handleToggleRed = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    const index = Number(event.currentTarget.dataset.index);
+    setHandTiles((prev) => {
+      return prev.map((tile, i) => {
+        if (i !== index || !isSuited(tile)) {
+          return tile;
+        }
+        return suitedTile(tile.suit,
+          tile.rank,
+          !tile.isRedDora);
+      });
+    });
+  },
+  [
+  ]);
+
+  const handleAddDora = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
+    const tile = tileFromKey(event.target.value);
+    if (tile === undefined) {
+      return;
+    }
+    setDoraIndicators((prev) => {
+      return prev.length >= MAX_DORA
+        ? prev
+        : [
+            ...prev,
+            tile
+          ];
+    });
+  },
+  [
+  ]);
+
+  const handleRemoveDora = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    const index = Number(event.currentTarget.dataset.index);
+    setDoraIndicators((prev) => {
+      return prev.filter((_, i) => {
+        return i !== index;
+      });
+    });
+  },
+  [
+  ]);
+
+  const handleAddUra = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
+    const tile = tileFromKey(event.target.value);
+    if (tile === undefined) {
+      return;
+    }
+    setUraIndicators((prev) => {
+      return prev.length >= MAX_DORA
+        ? prev
+        : [
+            ...prev,
+            tile
+          ];
+    });
+  },
+  [
+  ]);
+
+  const handleRemoveUra = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    const index = Number(event.currentTarget.dataset.index);
+    setUraIndicators((prev) => {
+      return prev.filter((_, i) => {
+        return i !== index;
+      });
+    });
+  },
+  [
+  ]);
+
   const tileCounts = useMemo(() => {
     const counts = new Map<string, number>();
     for (const tile of handTiles) {
@@ -184,10 +271,8 @@ const App = (): React.ReactNode => {
           riichi,
         },
         dora: {
-          indicators: [
-          ],
-          uraIndicators: [
-          ],
+          indicators: doraIndicators,
+          uraIndicators,
         },
         roundWind,
         seatWind,
@@ -200,7 +285,9 @@ const App = (): React.ReactNode => {
     riichi,
     roundWind,
     seatWind,
-    winType
+    winType,
+    doraIndicators,
+    uraIndicators
   ]);
 
   return (
@@ -251,19 +338,35 @@ const App = (): React.ReactNode => {
               <div className="flex flex-wrap gap-1">
                 {handTiles.map((tile, index) => {
                   const isWinning = index === effectiveWinning;
+                  const canBeRed = isSuited(tile) && tile.rank === 5;
+                  const isRed = isSuited(tile) && tile.isRedDora;
+                  const ringClass = isWinning ? ' ring-2 ring-rose-400' : '';
+                  const redClass = isRed ? ' text-rose-600' : '';
                   return (
                     <span
                       className="inline-flex items-center"
                       key={`${tileKey(tile)}-${index}`}
                     >
                       <button
-                        className={`${tileButtonClass} ${isWinning ? 'ring-2 ring-rose-400' : ''}`}
+                        className={`${tileButtonClass}${ringClass}${redClass}`}
                         data-index={index}
                         onClick={handleSetWinning}
                         type="button"
                       >
                         {tileLabel(tile)}
                       </button>
+                      {canBeRed
+                        ? (
+                            <button
+                              className={`px-1 text-xs ${isRed ? 'font-bold text-rose-600' : 'text-stone-400'}`}
+                              data-index={index}
+                              onClick={handleToggleRed}
+                              type="button"
+                            >
+                              赤
+                            </button>
+                          )
+                        : null}
                       <button
                         className="px-1 text-stone-400 hover:text-rose-500"
                         data-index={index}
@@ -344,6 +447,23 @@ const App = (): React.ReactNode => {
         </label>
       </section>
 
+      <IndicatorRow
+        indicators={doraIndicators}
+        onAdd={handleAddDora}
+        onRemove={handleRemoveDora}
+        title="ドラ表示牌（次の牌がドラ）"
+      />
+      {riichi
+        ? (
+            <IndicatorRow
+              indicators={uraIndicators}
+              onAdd={handleAddUra}
+              onRemove={handleRemoveUra}
+              title="裏ドラ表示牌"
+            />
+          )
+        : null}
+
       <section className="rounded border border-stone-300 p-4">
         <h2 className="mb-2 font-semibold">
           結果
@@ -351,6 +471,74 @@ const App = (): React.ReactNode => {
         <ScoreView score={score} />
       </section>
     </div>
+  );
+};
+
+type IndicatorRowProps = {
+  readonly indicators: readonly Tile[]
+  readonly onAdd: (event: React.ChangeEvent<HTMLSelectElement>) => void
+  readonly onRemove: (event: React.MouseEvent<HTMLButtonElement>) => void
+  readonly title: string
+};
+
+const IndicatorRow = ({
+  indicators, onAdd, onRemove, title,
+}: IndicatorRowProps): React.ReactNode => {
+  return (
+    <section className="space-y-2">
+      <h2 className="font-semibold">
+        {title}
+      </h2>
+      <div className="flex flex-wrap items-center gap-2">
+        <select
+          className="rounded border border-stone-300 px-2 py-1"
+          onChange={onAdd}
+          value=""
+        >
+          <option value="">
+            ＋ 追加
+          </option>
+          {ALL_TILES.map((tile) => {
+            const key = tileKey(tile);
+            return (
+              <option key={key} value={key}>
+                {tileLabel(tile)}
+              </option>
+            );
+          })}
+        </select>
+        {indicators.length === 0
+          ? (
+              <span className="text-stone-500">
+                なし
+              </span>
+            )
+          : (
+              <div className="flex flex-wrap gap-1">
+                {indicators.map((tile, index) => {
+                  return (
+                    <span
+                      className="inline-flex items-center"
+                      key={`${tileKey(tile)}-${index}`}
+                    >
+                      <span className="rounded border border-stone-300 bg-white px-2 py-1">
+                        {tileLabel(tile)}
+                      </span>
+                      <button
+                        className="px-1 text-stone-400 hover:text-rose-500"
+                        data-index={index}
+                        onClick={onRemove}
+                        type="button"
+                      >
+                        ×
+                      </button>
+                    </span>
+                  );
+                })}
+              </div>
+            )}
+      </div>
+    </section>
   );
 };
 

--- a/src/engine/calculateHandScore.test.ts
+++ b/src/engine/calculateHandScore.test.ts
@@ -167,6 +167,23 @@ describe('calculateHandScore',
         expect(result?.total).toBe(5200);
       });
 
+    it('ドラを加算: 平和+断么九+ドラ1 = 30符3翻 = 3900',
+      () => {
+        const result = calculateHandScore(pinfuHand(),
+          context({
+            dora: {
+              indicators: [
+                suitedTile('man',
+                  2)
+              ],
+              uraIndicators: [
+              ],
+            },
+          }));
+        expect(result?.han).toBe(3);
+        expect(result?.total).toBe(3900);
+      });
+
     it('役満 国士無双 子 ロン = 32000',
       () => {
         const hand = makeHand([

--- a/src/lib/tiles.test.ts
+++ b/src/lib/tiles.test.ts
@@ -3,11 +3,16 @@ import {
 } from 'vitest';
 
 import {
-  honorTile, suitedTile, type Tile
+  honorTile, isSuited, suitedTile, type Tile
 } from '../domain/index.ts';
 import {
-  addTileToHand, HAND_SIZE
+  addTileToHand, HAND_SIZE, toggleRedFive
 } from './tiles.ts';
+
+const isRedAt = (tiles: readonly Tile[], index: number): boolean => {
+  const tile = tiles[index];
+  return isSuited(tile) && tile.isRedDora;
+};
 
 describe('addTileToHand',
   () => {
@@ -82,5 +87,62 @@ describe('addTileToHand',
         const result = addTileToHand(full,
           honorTile('white'));
         expect(result).toHaveLength(HAND_SIZE);
+      });
+  });
+
+describe('toggleRedFive',
+  () => {
+    it('5を赤に切り替える',
+      () => {
+        const tiles: Tile[] = [
+          suitedTile('man',
+            5)
+        ];
+        const result = toggleRedFive(tiles,
+          0);
+        expect(isRedAt(result,
+          0)).toBe(true);
+      });
+
+    it('もう一度で赤を解除する',
+      () => {
+        const tiles: Tile[] = [
+          suitedTile('man',
+            5,
+            true)
+        ];
+        const result = toggleRedFive(tiles,
+          0);
+        expect(isRedAt(result,
+          0)).toBe(false);
+      });
+
+    it('同じ色の赤5は1枚まで（別の5を赤にすると前のは解除）',
+      () => {
+        const tiles: Tile[] = [
+          suitedTile('man',
+            5,
+            true),
+          suitedTile('man',
+            5)
+        ];
+        const result = toggleRedFive(tiles,
+          1);
+        expect(isRedAt(result,
+          0)).toBe(false);
+        expect(isRedAt(result,
+          1)).toBe(true);
+      });
+
+    it('5以外は変化しない',
+      () => {
+        const tiles: Tile[] = [
+          suitedTile('man',
+            4)
+        ];
+        const result = toggleRedFive(tiles,
+          0);
+        expect(isRedAt(result,
+          0)).toBe(false);
       });
   });

--- a/src/lib/tiles.ts
+++ b/src/lib/tiles.ts
@@ -109,3 +109,22 @@ export const addTileToHand = (tiles: readonly Tile[], tile: Tile): Tile[] => {
     tile
   ];
 };
+
+// index の牌（5のみ）の赤ドラ状態を切り替える。同じ色の赤5は1枚までとする。
+export const toggleRedFive = (tiles: readonly Tile[], index: number): Tile[] => {
+  const target = tiles[index];
+  if (target === undefined || !isSuited(target) || target.rank !== 5) {
+    return [
+      ...tiles
+    ];
+  }
+  const makeRed = !target.isRedDora;
+  return tiles.map((tile, i) => {
+    if (!isSuited(tile) || tile.rank !== 5 || tile.suit !== target.suit) {
+      return tile;
+    }
+    return suitedTile(tile.suit,
+      tile.rank,
+      makeRed && i === index);
+  });
+};


### PR DESCRIPTION
## 概要

ドラの指定UI（#6）。点数に直結するドラをエンジン（対応済み）に接続。

## 変更内容

- **表ドラ表示牌**: セレクトで追加・×で削除（最大5枚）。「次の牌がドラ」。
- **裏ドラ表示牌**: 同様。リーチ時のみ表示（エンジンもリーチ時のみ加算）。
- **赤ドラ**: 手牌の5に「赤」トグルを追加（`isRedDora`）。赤の5は赤字表示。
- 再利用コンポーネント `IndicatorRow` を追加。`context.dora` に接続。

## 確認

- `yarn lint` / `yarn test`（78）/ `yarn build` パス。
- E2Eテスト追加: 平和+断么九+ドラ1 = 30符3翻 = 3900。描画スモークにドラ節を追加。
- 各牌4枚上限は赤/非赤を区別せず合算（`tilesEqual`）で正しく機能。
- ※最終表示はブラウザでの目視を推奨。

Closes #6