### PR TITLE
feat: 副露（鳴き）入力を追加

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -22,6 +22,6 @@ describe('App',
         expect(html).toContain('海底');
         expect(html).toContain('副露（鳴き）');
         expect(html).toContain('ドラ表示牌（次の牌がドラ）');
-        expect(html).toContain('14 枚そろえると点数を表示します。');
+        expect(html).toContain('あと 14 枚選んでください');
       });
   });

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -20,6 +20,7 @@ describe('App',
         expect(html).toContain('牌を選んでください');
         expect(html).toContain('一発');
         expect(html).toContain('海底');
+        expect(html).toContain('副露（鳴き）');
         expect(html).toContain('ドラ表示牌（次の牌がドラ）');
         expect(html).toContain('14 枚そろえると点数を表示します。');
       });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -738,7 +738,11 @@ const App = (): React.ReactNode => {
         <h2 className="mb-2 font-semibold">
           結果
         </h2>
-        <ScoreView score={score} />
+        <ScoreView
+          handCount={handTiles.length}
+          requiredHandTiles={requiredHandTiles}
+          score={score}
+        />
       </section>
     </div>
   );
@@ -813,16 +817,22 @@ const IndicatorRow = ({
 };
 
 type ScoreViewProps = {
+  readonly handCount: number
+  readonly requiredHandTiles: number
   readonly score: HandScore | null | undefined
 };
 
 const ScoreView = ({
-  score,
+  handCount, requiredHandTiles, score,
 }: ScoreViewProps): React.ReactNode => {
   if (score === undefined) {
+    const shortage = requiredHandTiles - handCount;
+    const message = shortage > 0
+      ? `あと ${shortage} 枚選んでください（${handCount}/${requiredHandTiles}）`
+      : `手牌が ${-shortage} 枚多いです（${handCount}/${requiredHandTiles}）`;
     return (
       <p className="text-stone-500">
-        14 枚そろえると点数を表示します。
+        {message}
       </p>
     );
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import React, {
 } from 'react';
 
 import {
+  type Furo,
+  type FuroType,
   type Hand,
   isSuited,
   type Tile,
@@ -14,7 +16,7 @@ import {
   calculateHandScore, type HandScore
 } from './engine/index.ts';
 import {
-  addTileToHand, ALL_TILES, HAND_SIZE, tileFromKey, tileKey, tileLabel, toggleRedFive
+  addTileToHand, ALL_TILES, buildFuro, HAND_SIZE, tileFromKey, tileKey, tileLabel, toggleRedFive
 } from './lib/tiles.ts';
 
 type RiichiState = 'double' | 'none' | 'riichi';
@@ -63,6 +65,34 @@ const FLAGS: readonly FlagDef[] = [
     key: 'chankan',
     label: '槍槓',
     requires: 'ron',
+  }
+];
+
+type FuroTypeOption = {
+  readonly label: string
+  readonly value: FuroType
+};
+
+const FURO_TYPES: readonly FuroTypeOption[] = [
+  {
+    label: 'ポン',
+    value: 'pon',
+  },
+  {
+    label: 'チー',
+    value: 'chi',
+  },
+  {
+    label: '暗槓',
+    value: 'ankan',
+  },
+  {
+    label: '大明槓',
+    value: 'daiminkan',
+  },
+  {
+    label: '加槓',
+    value: 'kakan',
   }
 ];
 
@@ -135,6 +165,19 @@ const App = (): React.ReactNode => {
     setUraIndicators
   ] = useState<Tile[]>([
   ]);
+  const [
+    furos,
+    setFuros
+  ] = useState<Furo[]>([
+  ]);
+  const [
+    furoType,
+    setFuroType
+  ] = useState<FuroType>('pon');
+  const [
+    furoBaseKey,
+    setFuroBaseKey
+  ] = useState<string>('man-1');
 
   const handlePick = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
     const tile = tileFromKey(event.currentTarget.dataset.tile ?? '');
@@ -284,28 +327,87 @@ const App = (): React.ReactNode => {
   [
   ]);
 
+  const handleFuroType = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
+    setFuroType(event.target.value as FuroType);
+  },
+  [
+  ]);
+
+  const handleFuroBase = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
+    setFuroBaseKey(event.target.value);
+  },
+  [
+  ]);
+
+  const handleAddFuro = useCallback(() => {
+    const base = tileFromKey(furoBaseKey);
+    if (base === undefined) {
+      return;
+    }
+    const furo = buildFuro(furoType,
+      base);
+    if (furo === null) {
+      return; // チーで不正な牌など。
+    }
+    setFuros((prev) => {
+      return prev.length >= 4
+        ? prev
+        : [
+            ...prev,
+            furo
+          ];
+    });
+  },
+  [
+    furoBaseKey,
+    furoType
+  ]);
+
+  const handleRemoveFuro = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    const index = Number(event.currentTarget.dataset.index);
+    setFuros((prev) => {
+      return prev.filter((_, i) => {
+        return i !== index;
+      });
+    });
+  },
+  [
+  ]);
+
+  // ピッカーの4枚上限は手牌＋副露の合計で判定する。
   const tileCounts = useMemo(() => {
     const counts = new Map<string, number>();
-    for (const tile of handTiles) {
+    const countTile = (tile: Tile): void => {
       const key = tileKey(tile);
       counts.set(key,
         (counts.get(key) ?? 0) + 1);
+    };
+    for (const tile of handTiles) {
+      countTile(tile);
+    }
+    for (const furo of furos) {
+      for (const tile of furo.tiles) {
+        countTile(tile);
+      }
     }
     return counts;
   },
   [
-    handTiles
+    handTiles,
+    furos
   ]);
 
-  const isHandFull = handTiles.length >= HAND_SIZE;
+  // 必要な手牌枚数（副露1組につき3枚減る）。
+  const requiredHandTiles = HAND_SIZE - 3 * furos.length;
+  const isHandFull = handTiles.length >= requiredHandTiles;
 
   const effectiveWinning = winningIndex ?? handTiles.length - 1;
 
   const score = useMemo<HandScore | null | undefined>(() => {
-    if (handTiles.length !== HAND_SIZE) {
+    if (handTiles.length !== requiredHandTiles) {
       return undefined;
     }
-    if (effectiveWinning < 0 || effectiveWinning >= HAND_SIZE) {
+    if (effectiveWinning < 0 || effectiveWinning >= handTiles.length) {
       return undefined;
     }
     const winningTile = handTiles[effectiveWinning];
@@ -314,8 +416,7 @@ const App = (): React.ReactNode => {
     });
     const hand: Hand = {
       concealed,
-      furo: [
-      ],
+      furo: furos,
       winningTile,
     };
     // 状況役は和了種別・立直状態と矛盾しないように整える（エンジンも同様にガード）。
@@ -342,6 +443,7 @@ const App = (): React.ReactNode => {
   },
   [
     handTiles,
+    requiredHandTiles,
     effectiveWinning,
     riichiState,
     flags,
@@ -349,7 +451,8 @@ const App = (): React.ReactNode => {
     seatWind,
     winType,
     doraIndicators,
-    uraIndicators
+    uraIndicators,
+    furos
   ]);
 
   return (
@@ -363,7 +466,7 @@ const App = (): React.ReactNode => {
           牌を選ぶ（
           {handTiles.length}
           /
-          {HAND_SIZE}
+          {requiredHandTiles}
           ）
         </h2>
         <div className="flex flex-wrap gap-1">
@@ -449,6 +552,81 @@ const App = (): React.ReactNode => {
         >
           クリア
         </button>
+      </section>
+
+      <section className="space-y-2">
+        <h2 className="font-semibold">
+          副露（鳴き）
+        </h2>
+        <div className="flex flex-wrap items-center gap-2">
+          <select
+            className="rounded border border-stone-300 px-2 py-1"
+            onChange={handleFuroType}
+            value={furoType}
+          >
+            {FURO_TYPES.map((furoOption) => {
+              return (
+                <option key={furoOption.value} value={furoOption.value}>
+                  {furoOption.label}
+                </option>
+              );
+            })}
+          </select>
+          <select
+            className="rounded border border-stone-300 px-2 py-1"
+            onChange={handleFuroBase}
+            value={furoBaseKey}
+          >
+            {ALL_TILES.map((tile) => {
+              const key = tileKey(tile);
+              return (
+                <option key={key} value={key}>
+                  {tileLabel(tile)}
+                </option>
+              );
+            })}
+          </select>
+          <button
+            className="rounded border border-stone-300 px-3 py-1 text-sm hover:bg-stone-100"
+            disabled={furos.length >= 4}
+            onClick={handleAddFuro}
+            type="button"
+          >
+            追加
+          </button>
+        </div>
+        {furos.length === 0
+          ? (
+              <p className="text-stone-500">
+                なし（チーは1〜7の数牌のみ）
+              </p>
+            )
+          : (
+              <div className="flex flex-wrap gap-2">
+                {furos.map((furo, index) => {
+                  return (
+                    <span
+                      className="inline-flex items-center rounded border border-stone-300 px-1"
+                      key={`${furo.type}-${tileKey(furo.tiles[0])}-${index}`}
+                    >
+                      <span className="px-1">
+                        {furo.tiles.map((tile) => {
+                          return tileLabel(tile);
+                        }).join('')}
+                      </span>
+                      <button
+                        className="px-1 text-stone-400 hover:text-rose-500"
+                        data-index={index}
+                        onClick={handleRemoveFuro}
+                        type="button"
+                      >
+                        ×
+                      </button>
+                    </span>
+                  );
+                })}
+              </div>
+            )}
       </section>
 
       <section className="flex flex-wrap gap-4">

--- a/src/engine/calculateHandScore.test.ts
+++ b/src/engine/calculateHandScore.test.ts
@@ -209,6 +209,38 @@ describe('calculateHandScore',
         expect(result?.total).toBe(32000);
       });
 
+    it('副露あり: 白ポン(役牌) 子ロン = 30符1翻 = 1000',
+      () => {
+        const furo: Hand['furo'] = [
+          {
+            calledFrom: 'shimocha',
+            tiles: [
+              honorTile('white'),
+              honorTile('white'),
+              honorTile('white')
+            ],
+            type: 'pon',
+          }
+        ];
+        const hand = makeHand([
+          ...suited('man',
+            '234567'),
+          ...suited('pin',
+            '234'),
+          ...suited('sou',
+            '9')
+        ],
+        suitedTile('sou',
+          9),
+        furo);
+        const result = calculateHandScore(hand,
+          context());
+        expect(result?.yaku.map((yaku) => {
+          return yaku.name;
+        })).toContain('役牌（白）');
+        expect(result?.total).toBe(1000);
+      });
+
     it('役無し（鳴き・役牌なし・断么九不成立）は null',
       () => {
         const furo: Hand['furo'] = [

--- a/src/lib/tiles.test.ts
+++ b/src/lib/tiles.test.ts
@@ -208,4 +208,14 @@ describe('buildFuro',
         expect(furo?.tiles).toHaveLength(4);
         expect(furo?.calledFrom).toBe('shimocha');
       });
+
+    it('加槓は4枚・鳴き元あり（門前ではない）',
+      () => {
+        const furo = buildFuro('kakan',
+          suitedTile('pin',
+            2));
+        expect(furo?.type).toBe('kakan');
+        expect(furo?.tiles).toHaveLength(4);
+        expect(furo?.calledFrom).toBe('shimocha');
+      });
   });

--- a/src/lib/tiles.test.ts
+++ b/src/lib/tiles.test.ts
@@ -6,7 +6,7 @@ import {
   honorTile, isSuited, suitedTile, type Tile
 } from '../domain/index.ts';
 import {
-  addTileToHand, HAND_SIZE, toggleRedFive
+  addTileToHand, buildFuro, HAND_SIZE, toggleRedFive
 } from './tiles.ts';
 
 const isRedAt = (tiles: readonly Tile[], index: number): boolean => {
@@ -144,5 +144,68 @@ describe('toggleRedFive',
           0);
         expect(isRedAt(result,
           0)).toBe(false);
+      });
+  });
+
+describe('buildFuro',
+  () => {
+    it('ポンは同じ牌3枚',
+      () => {
+        const furo = buildFuro('pon',
+          suitedTile('man',
+            5));
+        expect(furo?.type).toBe('pon');
+        expect(furo?.tiles).toHaveLength(3);
+        expect(furo?.calledFrom).toBe('shimocha');
+      });
+
+    it('チーは連続3枚・上家から',
+      () => {
+        const furo = buildFuro('chi',
+          suitedTile('man',
+            3));
+        expect(furo?.type).toBe('chi');
+        expect(furo?.tiles).toHaveLength(3);
+        expect(furo?.calledFrom).toBe('kamicha');
+        const ranks = furo?.tiles.map((tile) => {
+          return isSuited(tile) ? tile.rank : 0;
+        });
+        expect(ranks).toStrictEqual([
+          3,
+          4,
+          5
+        ]);
+      });
+
+    it('チーは8以上の数牌では作れない',
+      () => {
+        expect(buildFuro('chi',
+          suitedTile('man',
+            8))).toBeNull();
+      });
+
+    it('チーは字牌では作れない',
+      () => {
+        expect(buildFuro('chi',
+          honorTile('east'))).toBeNull();
+      });
+
+    it('暗槓は4枚・鳴き元なし',
+      () => {
+        const furo = buildFuro('ankan',
+          suitedTile('pin',
+            2));
+        expect(furo?.type).toBe('ankan');
+        expect(furo?.tiles).toHaveLength(4);
+        expect(furo?.calledFrom).toBeNull();
+      });
+
+    it('大明槓は4枚・鳴き元あり',
+      () => {
+        const furo = buildFuro('daiminkan',
+          suitedTile('pin',
+            2));
+        expect(furo?.tiles).toHaveLength(4);
+        expect(furo?.calledFrom).toBe('shimocha');
       });
   });

--- a/src/lib/tiles.ts
+++ b/src/lib/tiles.ts
@@ -1,6 +1,8 @@
 // UI 用の牌ヘルパー（表示ラベル・牌一覧・キー対応）。
 
 import {
+  type Furo,
+  type FuroType,
   type Honor,
   honorTile,
   isSuited,
@@ -127,4 +129,46 @@ export const toggleRedFive = (tiles: readonly Tile[], index: number): Tile[] => 
       tile.rank,
       makeRed && i === index);
   });
+};
+
+// 副露（鳴き）を組み立てる。チーは上家から・数牌の1〜7のみ。作れない場合は null。
+export const buildFuro = (type: FuroType, base: Tile): Furo | null => {
+  if (type === 'chi') {
+    if (!isSuited(base) || base.rank > 7) {
+      return null;
+    }
+    return {
+      calledFrom: 'kamicha',
+      tiles: [
+        base,
+        suitedTile(base.suit,
+          (base.rank + 1) as Rank),
+        suitedTile(base.suit,
+          (base.rank + 2) as Rank)
+      ],
+      type: 'chi',
+    };
+  }
+  if (type === 'pon') {
+    return {
+      calledFrom: 'shimocha',
+      tiles: [
+        base,
+        base,
+        base
+      ],
+      type: 'pon',
+    };
+  }
+  // ankan / daiminkan / kakan
+  return {
+    calledFrom: type === 'ankan' ? null : 'shimocha',
+    tiles: [
+      base,
+      base,
+      base,
+      base
+    ],
+    type,
+  };
 };


### PR DESCRIPTION
## 概要

副露（鳴き）の入力UI（#7）。これまで門前手のみだった計算を、ポン/チー/各種カンを含む鳴き手に対応。

## 変更内容

- 副露セクション: 種別（ポン/チー/暗槓/大明槓/加槓）+ 牌を選んで「追加」。最大4組。×で削除。
- `buildFuro(type, base)`（`lib/tiles.ts`）で副露を生成。**チーは上家から・1〜7の数牌のみ**（不正は無視）。
- 副露数に応じて**必要手牌枚数を 14 − 3×組数**に調整（牌ピッカーのカウント表示・上限判定に反映）。
- ピッカーの**4枚上限は手牌＋副露の合計**で判定。
- `hand.furo` に接続。鳴き手は門前役が食い下がり/不成立になる（エンジン側で処理、暗槓のみ門前維持）。

## 確認

- `yarn lint` / `yarn test`（89）/ `yarn build` パス。
- `buildFuro` 単体テスト（ポン/チー/不正チー/暗槓/大明槓）+ E2E（白ポン子ロン=1000・役牌（白））+ 描画スモーク（副露節）。
- ※最終表示はブラウザでの目視を推奨。

Closes #7