### PR TITLE
ci: GitHub Pages へ自動デプロイ

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# 同時実行は1つに。進行中のデプロイは中断しない。
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+      - name: Setup corepack
+        run: corepack enable
+      - name: Install dependencies
+        run: yarn
+      - name: Build
+        run: yarn build
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="ja">
 
 <head>
   <meta charset="UTF-8" />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,8 @@ import { defineConfig } from 'vite';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  // GitHub Pages（プロジェクトページ）のサブパス配下でも動くよう相対パスにする。
+  base: './',
   plugins: [
     react()
   ],


### PR DESCRIPTION
## 概要

`main` への push でビルド成果物を GitHub Pages に自動公開する（#30）。

## 変更内容

- `.github/workflows/deploy.yml`: build（yarn build）→ `actions/upload-pages-artifact`(dist) → `actions/deploy-pages`。`workflow_dispatch` で手動実行も可。`permissions: pages:write / id-token:write`、`concurrency: pages`。
- `actions/configure-pages@v5` の `enablement: true` で Pages を自動有効化（手動設定不要）。
- `vite.config.ts`: `base: './'`（相対パス）でプロジェクトページのサブパス配下でも動作。
- `index.html`: `lang="ja"`。

## 公開URL（マージ後）

`https://fumimi23.github.io/mahjong-score-calculation/`

## 確認

- `yarn lint` / `yarn test`（90）/ `yarn build` パス。ビルド成果物の index.html が相対パス（`./assets/...`）になることを確認。
- deploy ワークフローは `main` への push でのみ起動（本PRブランチでは走らない）。**マージ時に初回デプロイ**。

Closes #30