### PR TITLE
feat: 副露を手牌と統合表示し、鳴き牌の赤5に対応

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -20,7 +20,7 @@ describe('App',
         expect(html).toContain('牌を選んでください');
         expect(html).toContain('一発');
         expect(html).toContain('海底');
-        expect(html).toContain('副露（鳴き）');
+        expect(html).toContain('鳴きを追加');
         expect(html).toContain('和了条件');
         expect(html).toContain('ドラ表示牌（次の牌がドラ）');
         expect(html).toContain('あと 14 枚選んでください');

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,7 +24,8 @@ import {
   tileFromKey,
   tileKey,
   tileLabel,
-  toggleRedFive
+  toggleRedFive,
+  toggleRedInFuro
 } from './lib/tiles.ts';
 import {
   type ScorePayments
@@ -240,6 +241,8 @@ const App = (): React.ReactNode => {
     setHandTiles([
     ]);
     setWinningIndex(null);
+    setFuros([
+    ]);
   },
   [
   ]);
@@ -400,6 +403,19 @@ const App = (): React.ReactNode => {
   [
   ]);
 
+  // 副露内の5を赤ドラに切り替える。
+  const handleToggleFuroRed = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
+    const furoIndex = Number(event.currentTarget.dataset.furo);
+    const tileIndex = Number(event.currentTarget.dataset.tile);
+    setFuros((prev) => {
+      return toggleRedInFuro(prev,
+        furoIndex,
+        tileIndex);
+    });
+  },
+  [
+  ]);
+
   // ピッカーの4枚上限は手牌＋副露の合計で判定する。
   const tileCounts = useMemo(() => {
     const counts = new Map<string, number>();
@@ -524,83 +540,132 @@ const App = (): React.ReactNode => {
 
         <section className={sectionClass}>
           <h2 className="font-semibold">
-            手牌（クリックでアガリ牌に指定 / ×で削除）
+            手牌
+            <span className="ml-2 text-sm font-normal text-stone-500">
+              （門前
+              {handTiles.length}
+              枚 ＋ 副露
+              {furos.length}
+              組 / 牌クリックでアガリ牌指定）
+            </span>
           </h2>
-          {handTiles.length === 0
+          {handTiles.length === 0 && furos.length === 0
             ? (
                 <p className="text-stone-500">
                   牌を選んでください。
                 </p>
               )
             : (
-                <div className="flex flex-wrap gap-1">
-                  {handTiles.map((tile, index) => {
-                    const isWinning = index === effectiveWinning;
-                    const canBeRed = isSuited(tile) && tile.rank === 5;
-                    const isRed = isSuited(tile) && tile.isRedDora;
-                    const ringClass = isWinning ? ' ring-2 ring-rose-500 ring-offset-1' : '';
-                    return (
-                      <span
-                        className="inline-flex flex-col items-center"
-                        key={`${tileKey(tile)}-${index}`}
-                      >
-                        <button
-                          className={`${tileFaceClass} ${tileColorClass(tile)}${ringClass}`}
-                          data-index={index}
-                          onClick={handleSetWinning}
-                          title="クリックでアガリ牌に指定"
-                          type="button"
+                <div className="flex flex-wrap items-start gap-3">
+                  <div className="flex flex-wrap gap-1">
+                    {handTiles.map((tile, index) => {
+                      const isWinning = index === effectiveWinning;
+                      const canBeRed = isSuited(tile) && tile.rank === 5;
+                      const isRed = isSuited(tile) && tile.isRedDora;
+                      const ringClass = isWinning ? ' ring-2 ring-rose-500 ring-offset-1' : '';
+                      return (
+                        <span
+                          className="inline-flex flex-col items-center"
+                          key={`${tileKey(tile)}-${index}`}
                         >
-                          {tileLabel(tile)}
-                        </button>
-                        <span className="mt-0.5 flex items-center gap-1 text-xs">
-                          {isWinning
-                            ? (
-                                <span className="text-rose-500">
-                                  和
-                                </span>
-                              )
-                            : null}
-                          {canBeRed
-                            ? (
-                                <button
-                                  className={isRed ? 'font-bold text-red-600' : 'text-stone-400'}
-                                  data-index={index}
-                                  onClick={handleToggleRed}
-                                  type="button"
-                                >
-                                  赤
-                                </button>
-                              )
-                            : null}
                           <button
-                            className="text-stone-400 hover:text-rose-500"
+                            className={`${tileFaceClass} ${tileColorClass(tile)}${ringClass}`}
                             data-index={index}
-                            onClick={handleRemove}
+                            onClick={handleSetWinning}
+                            title="クリックでアガリ牌に指定"
                             type="button"
                           >
-                            ×
+                            {tileLabel(tile)}
                           </button>
+                          <span className="mt-0.5 flex items-center gap-1 text-xs">
+                            {isWinning
+                              ? (
+                                  <span className="text-rose-500">
+                                    和
+                                  </span>
+                                )
+                              : null}
+                            {canBeRed
+                              ? (
+                                  <button
+                                    className={isRed ? 'font-bold text-red-600' : 'text-stone-400'}
+                                    data-index={index}
+                                    onClick={handleToggleRed}
+                                    type="button"
+                                  >
+                                    赤
+                                  </button>
+                                )
+                              : null}
+                            <button
+                              className="text-stone-400 hover:text-rose-500"
+                              data-index={index}
+                              onClick={handleRemove}
+                              type="button"
+                            >
+                              ×
+                            </button>
+                          </span>
                         </span>
-                      </span>
+                      );
+                    })}
+                  </div>
+                  {furos.map((furo, furoIndex) => {
+                    const typeLabel = FURO_TYPES.find((option) => {
+                      return option.value === furo.type;
+                    })?.label ?? furo.type;
+                    return (
+                      <div
+                        className="flex flex-col items-center rounded-md bg-stone-100 p-1"
+                        key={`${furo.type}-${tileKey(furo.tiles[0])}-${furoIndex}`}
+                      >
+                        <div className="flex gap-0.5">
+                          {furo.tiles.map((tile, tileIndex) => {
+                            const canBeRed = isSuited(tile) && tile.rank === 5;
+                            const isRed = isSuited(tile) && tile.isRedDora;
+                            return (
+                              <span
+                                className="inline-flex flex-col items-center"
+                                key={`${tileKey(tile)}-${tileIndex}`}
+                              >
+                                <span className={`${tileFaceClass} ${tileColorClass(tile)}`}>
+                                  {tileLabel(tile)}
+                                </span>
+                                {canBeRed
+                                  ? (
+                                      <button
+                                        className={isRed ? 'text-xs font-bold text-red-600' : 'text-xs text-stone-400'}
+                                        data-furo={furoIndex}
+                                        data-tile={tileIndex}
+                                        onClick={handleToggleFuroRed}
+                                        type="button"
+                                      >
+                                        赤
+                                      </button>
+                                    )
+                                  : null}
+                              </span>
+                            );
+                          })}
+                        </div>
+                        <button
+                          className="mt-0.5 text-xs text-stone-500 hover:text-rose-500"
+                          data-index={furoIndex}
+                          onClick={handleRemoveFuro}
+                          type="button"
+                        >
+                          {typeLabel}
+                          {' ×'}
+                        </button>
+                      </div>
                     );
                   })}
                 </div>
               )}
-          <button
-            className="rounded border border-stone-300 px-3 py-1 text-sm hover:bg-stone-100"
-            onClick={handleClear}
-            type="button"
-          >
-            クリア
-          </button>
-        </section>
-
-        <section className={sectionClass}>
-          <h2 className="font-semibold">
-            副露（鳴き）
-          </h2>
           <div className="flex flex-wrap items-center gap-2">
+            <span className="text-sm text-stone-500">
+              鳴きを追加：
+            </span>
             <select
               className={selectClass}
               onChange={handleFuroType}
@@ -636,46 +701,14 @@ const App = (): React.ReactNode => {
             >
               追加
             </button>
+            <button
+              className="rounded border border-stone-300 px-3 py-1 text-sm hover:bg-stone-100"
+              onClick={handleClear}
+              type="button"
+            >
+              クリア
+            </button>
           </div>
-          {furos.length === 0
-            ? (
-                <p className="text-stone-500">
-                  なし（チーは1〜7の数牌のみ）
-                </p>
-              )
-            : (
-                <div className="flex flex-wrap gap-2">
-                  {furos.map((furo, index) => {
-                    return (
-                      <span
-                        className="inline-flex items-center rounded border border-stone-300 px-1"
-                        key={`${furo.type}-${tileKey(furo.tiles[0])}-${index}`}
-                      >
-                        <span className="flex px-1 font-bold">
-                          {furo.tiles.map((tile, tileIndex) => {
-                            return (
-                              <span
-                                className={`px-0.5 ${tileColorClass(tile)}`}
-                                key={`${tileKey(tile)}-${tileIndex}`}
-                              >
-                                {tileLabel(tile)}
-                              </span>
-                            );
-                          })}
-                        </span>
-                        <button
-                          className="px-1 text-stone-400 hover:text-rose-500"
-                          data-index={index}
-                          onClick={handleRemoveFuro}
-                          type="button"
-                        >
-                          ×
-                        </button>
-                      </span>
-                    );
-                  })}
-                </div>
-              )}
         </section>
 
         <section className={sectionClass}>

--- a/src/engine/calculateHandScore.test.ts
+++ b/src/engine/calculateHandScore.test.ts
@@ -241,6 +241,41 @@ describe('calculateHandScore',
         expect(result?.total).toBe(1000);
       });
 
+    it('副露内の赤5がドラに加算される',
+      () => {
+        const furo: Hand['furo'] = [
+          {
+            calledFrom: 'shimocha',
+            tiles: [
+              suitedTile('pin',
+                5,
+                true),
+              suitedTile('pin',
+                5),
+              suitedTile('pin',
+                5)
+            ],
+            type: 'pon',
+          }
+        ];
+        const hand = makeHand([
+          ...suited('man',
+            '234678'),
+          ...suited('pin',
+            '234'),
+          ...suited('sou',
+            '3')
+        ],
+        suitedTile('sou',
+          3),
+        furo);
+        const result = calculateHandScore(hand,
+          context());
+        expect(result?.yaku.map((yaku) => {
+          return yaku.name;
+        })).toContain('赤ドラ');
+      });
+
     it('役無し（鳴き・役牌なし・断么九不成立）は null',
       () => {
         const furo: Hand['furo'] = [

--- a/src/lib/tiles.test.ts
+++ b/src/lib/tiles.test.ts
@@ -3,10 +3,10 @@ import {
 } from 'vitest';
 
 import {
-  honorTile, isSuited, suitedTile, type Tile
+  type Furo, honorTile, isSuited, suitedTile, type Tile
 } from '../domain/index.ts';
 import {
-  addTileToHand, buildFuro, HAND_SIZE, toggleRedFive
+  addTileToHand, buildFuro, HAND_SIZE, toggleRedFive, toggleRedInFuro
 } from './tiles.ts';
 
 const isRedAt = (tiles: readonly Tile[], index: number): boolean => {
@@ -217,5 +217,59 @@ describe('buildFuro',
         expect(furo?.type).toBe('kakan');
         expect(furo?.tiles).toHaveLength(4);
         expect(furo?.calledFrom).toBe('shimocha');
+      });
+  });
+
+describe('toggleRedInFuro',
+  () => {
+    const ponOf5 = (): Furo => {
+      const furo = buildFuro('pon',
+        suitedTile('man',
+          5));
+      if (furo === null) {
+        throw new Error('ポンの生成に失敗');
+      }
+      return furo;
+    };
+
+    it('副露内の5を赤に切り替える',
+      () => {
+        const result = toggleRedInFuro([
+          ponOf5()
+        ],
+        0,
+        0);
+        const tile = result[0].tiles[0];
+        expect(isSuited(tile) && tile.isRedDora).toBe(true);
+      });
+
+    it('同じ面子内の赤5は1枚まで（別の5を赤にすると前のは解除）',
+      () => {
+        const reddened = toggleRedInFuro([
+          ponOf5()
+        ],
+        0,
+        0);
+        const result = toggleRedInFuro(reddened,
+          0,
+          1);
+        expect(isSuited(result[0].tiles[0]) && result[0].tiles[0].isRedDora).toBe(false);
+        expect(isSuited(result[0].tiles[1]) && result[0].tiles[1].isRedDora).toBe(true);
+      });
+
+    it('5以外は変化しない',
+      () => {
+        const chi = buildFuro('chi',
+          suitedTile('man',
+            1));
+        if (chi === null) {
+          throw new Error('チーの生成に失敗');
+        }
+        const result = toggleRedInFuro([
+          chi
+        ],
+        0,
+        0);
+        expect(isSuited(result[0].tiles[0]) && result[0].tiles[0].isRedDora).toBe(false);
       });
   });

--- a/src/lib/tiles.ts
+++ b/src/lib/tiles.ts
@@ -195,3 +195,32 @@ export const buildFuro = (type: FuroType, base: Tile): Furo | null => {
     type,
   };
 };
+
+// 副露内の5（tileIndex）の赤ドラ状態を切り替える。同じ面子内の同色5は1枚まで赤。
+export const toggleRedInFuro = (
+  furos: readonly Furo[],
+  furoIndex: number,
+  tileIndex: number
+): Furo[] => {
+  return furos.map((furo, fi) => {
+    if (fi !== furoIndex) {
+      return furo;
+    }
+    const target = furo.tiles[tileIndex];
+    if (target === undefined || !isSuited(target) || target.rank !== 5) {
+      return furo;
+    }
+    const makeRed = !target.isRedDora;
+    return {
+      ...furo,
+      tiles: furo.tiles.map((tile, ti) => {
+        if (!isSuited(tile) || tile.rank !== 5 || tile.suit !== target.suit) {
+          return tile;
+        }
+        return suitedTile(tile.suit,
+          tile.rank,
+          makeRed && ti === tileIndex);
+      }),
+    };
+  });
+};


### PR DESCRIPTION
## 概要

副露（鳴き）の見せ方を改善（#35）。「鳴きが手牌に含まれない」分かりにくさと、鳴いた牌の赤5が指定できない問題を解消。

## 変更内容（案A）

- **表示の統合**: 副露を別セクションではなく**手牌エリアに統合**。門前牌 ＋ 晒し面子（薄グレー背景でグループ表示）を横に並べ、1つの手牌として読めるように。見出しに内訳「門前N枚 ＋ 副露M組」。
- **鳴きの赤5**: 鳴いた面子内の5に「赤」トグルを追加（手牌の5と同操作）。同一面子内の同色5は1枚まで（`toggleRedInFuro`）。
- 鳴きの追加コントロール・クリアを手牌エリアに集約。クリアは副露も対象。
- 入力モデル（鳴き種別＋牌の指定）は維持（点数計算に鳴き種別が必須なため）。

## 確認

- `yarn lint` / `yarn test`（94）/ `yarn build` パス。
- `toggleRedInFuro` 単体テスト＋**副露内の赤5がドラ加算される E2E テスト**を追加。
- ※最終表示はブラウザでの目視を推奨。

Closes #35