### PR TITLE
feat: 赤5の同色重複を手牌＋副露で横断ガード

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,8 +24,8 @@ import {
   tileFromKey,
   tileKey,
   tileLabel,
-  toggleRedFive,
-  toggleRedInFuro
+  toggleFuroRedFive,
+  toggleHandRedFive
 } from './lib/tiles.ts';
 import {
   type ScorePayments
@@ -289,15 +289,18 @@ const App = (): React.ReactNode => {
   [
   ]);
 
-  // 手牌の5を赤ドラに切り替える（同色の赤5は1枚まで）。
+  // 手牌の5を赤ドラに切り替える（同色の赤5は手牌＋副露を通じて1枚まで）。
   const handleToggleRed = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
     const index = Number(event.currentTarget.dataset.index);
-    setHandTiles((prev) => {
-      return toggleRedFive(prev,
-        index);
-    });
+    const next = toggleHandRedFive(handTiles,
+      furos,
+      index);
+    setHandTiles(next.hand);
+    setFuros(next.furos);
   },
   [
+    handTiles,
+    furos
   ]);
 
   const handleAddDora = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
@@ -403,17 +406,20 @@ const App = (): React.ReactNode => {
   [
   ]);
 
-  // 副露内の5を赤ドラに切り替える。
+  // 副露内の5を赤ドラに切り替える（同色の赤5は手牌＋副露を通じて1枚まで）。
   const handleToggleFuroRed = useCallback((event: React.MouseEvent<HTMLButtonElement>) => {
     const furoIndex = Number(event.currentTarget.dataset.furo);
     const tileIndex = Number(event.currentTarget.dataset.tile);
-    setFuros((prev) => {
-      return toggleRedInFuro(prev,
-        furoIndex,
-        tileIndex);
-    });
+    const next = toggleFuroRedFive(handTiles,
+      furos,
+      furoIndex,
+      tileIndex);
+    setHandTiles(next.hand);
+    setFuros(next.furos);
   },
   [
+    handTiles,
+    furos
   ]);
 
   // ピッカーの4枚上限は手牌＋副露の合計で判定する。

--- a/src/lib/tiles.test.ts
+++ b/src/lib/tiles.test.ts
@@ -6,7 +6,13 @@ import {
   type Furo, honorTile, isSuited, suitedTile, type Tile
 } from '../domain/index.ts';
 import {
-  addTileToHand, buildFuro, HAND_SIZE, toggleRedFive, toggleRedInFuro
+  addTileToHand,
+  buildFuro,
+  HAND_SIZE,
+  toggleFuroRedFive,
+  toggleHandRedFive,
+  toggleRedFive,
+  toggleRedInFuro
 } from './tiles.ts';
 
 const isRedAt = (tiles: readonly Tile[], index: number): boolean => {
@@ -271,5 +277,72 @@ describe('toggleRedInFuro',
         0,
         0);
         expect(isSuited(result[0].tiles[0]) && result[0].tiles[0].isRedDora).toBe(false);
+      });
+  });
+
+describe('赤5の横断ガード',
+  () => {
+    const ponRed5 = (): Furo => {
+      const furo = toggleRedInFuro([
+        buildFuro('pon',
+          suitedTile('pin',
+            5)) as Furo
+      ],
+      0,
+      0);
+      return furo[0];
+    };
+
+    it('手牌の5筒を赤にすると、副露の赤5筒が解除される',
+      () => {
+        const hand: Tile[] = [
+          suitedTile('pin',
+            5)
+        ];
+        const result = toggleHandRedFive(hand,
+          [
+            ponRed5()
+          ],
+          0);
+        expect(isSuited(result.hand[0]) && result.hand[0].isRedDora).toBe(true);
+        const furoTile = result.furos[0].tiles[0];
+        expect(isSuited(furoTile) && furoTile.isRedDora).toBe(false);
+      });
+
+    it('副露の5筒を赤にすると、手牌の赤5筒が解除される',
+      () => {
+        const hand: Tile[] = [
+          suitedTile('pin',
+            5,
+            true)
+        ];
+        const plainPon = buildFuro('pon',
+          suitedTile('pin',
+            5)) as Furo;
+        const result = toggleFuroRedFive(hand,
+          [
+            plainPon
+          ],
+          0,
+          0);
+        expect(isSuited(result.hand[0]) && result.hand[0].isRedDora).toBe(false);
+        const furoTile = result.furos[0].tiles[0];
+        expect(isSuited(furoTile) && furoTile.isRedDora).toBe(true);
+      });
+
+    it('副露の5筒を赤にすると、別の副露の赤5筒が解除される',
+      () => {
+        const result = toggleFuroRedFive([
+        ],
+        [
+          ponRed5(),
+          buildFuro('pon',
+            suitedTile('pin',
+              5)) as Furo
+        ],
+        1,
+        0);
+        expect(isSuited(result.furos[0].tiles[0]) && result.furos[0].tiles[0].isRedDora).toBe(false);
+        expect(isSuited(result.furos[1].tiles[0]) && result.furos[1].tiles[0].isRedDora).toBe(true);
       });
   });

--- a/src/lib/tiles.test.ts
+++ b/src/lib/tiles.test.ts
@@ -345,4 +345,39 @@ describe('赤5の横断ガード',
         expect(isSuited(result.furos[0].tiles[0]) && result.furos[0].tiles[0].isRedDora).toBe(false);
         expect(isSuited(result.furos[1].tiles[0]) && result.furos[1].tiles[0].isRedDora).toBe(true);
       });
+
+    it('別スートの赤5は解除されない（手牌5筒を赤にしても副露の赤5索は残る）',
+      () => {
+        const redSou = toggleRedInFuro([
+          buildFuro('pon',
+            suitedTile('sou',
+              5)) as Furo
+        ],
+        0,
+        0);
+        const result = toggleHandRedFive([
+          suitedTile('pin',
+            5)
+        ],
+        redSou,
+        0);
+        const furoTile = result.furos[0].tiles[0];
+        expect(isSuited(furoTile) && furoTile.isRedDora).toBe(true);
+      });
+
+    it('赤を解除するときは他の場所を触らない',
+      () => {
+        const result = toggleHandRedFive([
+          suitedTile('pin',
+            5,
+            true)
+        ],
+        [
+          ponRed5()
+        ],
+        0);
+        expect(isSuited(result.hand[0]) && result.hand[0].isRedDora).toBe(false);
+        const furoTile = result.furos[0].tiles[0];
+        expect(isSuited(furoTile) && furoTile.isRedDora).toBe(true);
+      });
   });

--- a/src/lib/tiles.ts
+++ b/src/lib/tiles.ts
@@ -196,6 +196,18 @@ export const buildFuro = (type: FuroType, base: Tile): Furo | null => {
   };
 };
 
+// 指定スートの5の赤ドラをすべて解除する。
+export const clearRedFivesOfSuit = (tiles: readonly Tile[], suit: Suit): Tile[] => {
+  return tiles.map((tile) => {
+    if (isSuited(tile) && tile.rank === 5 && tile.suit === suit) {
+      return suitedTile(suit,
+        5,
+        false);
+    }
+    return tile;
+  });
+};
+
 // 副露内の5（tileIndex）の赤ドラ状態を切り替える。同じ面子内の同色5は1枚まで赤。
 export const toggleRedInFuro = (
   furos: readonly Furo[],
@@ -223,4 +235,88 @@ export const toggleRedInFuro = (
       }),
     };
   });
+};
+
+// 手牌＋副露を横断した赤5切り替えの結果。
+export type RedToggleResult = {
+  readonly furos: Furo[]
+  readonly hand: Tile[]
+};
+
+// 手牌の5（index）の赤を切り替える。赤にする場合は同色の赤5を全副露からも解除し、同色1枚を保証する。
+export const toggleHandRedFive = (
+  hand: readonly Tile[],
+  furos: readonly Furo[],
+  index: number
+): RedToggleResult => {
+  const target = hand[index];
+  if (target === undefined || !isSuited(target) || target.rank !== 5) {
+    return {
+      furos: [
+        ...furos
+      ],
+      hand: [
+        ...hand
+      ],
+    };
+  }
+  const makeRed = !target.isRedDora;
+  return {
+    furos: makeRed
+      ? furos.map((furo) => {
+        return {
+          ...furo,
+          tiles: clearRedFivesOfSuit(furo.tiles,
+            target.suit),
+        };
+      })
+      : [
+          ...furos
+        ],
+    hand: toggleRedFive(hand,
+      index),
+  };
+};
+
+// 副露の5（furoIndex, tileIndex）の赤を切り替える。赤にする場合は同色の赤5を手牌・他の副露からも解除する。
+export const toggleFuroRedFive = (
+  hand: readonly Tile[],
+  furos: readonly Furo[],
+  furoIndex: number,
+  tileIndex: number
+): RedToggleResult => {
+  const target = furos[furoIndex]?.tiles[tileIndex];
+  if (target === undefined || !isSuited(target) || target.rank !== 5) {
+    return {
+      furos: [
+        ...furos
+      ],
+      hand: [
+        ...hand
+      ],
+    };
+  }
+  const makeRed = !target.isRedDora;
+  const toggled = toggleRedInFuro(furos,
+    furoIndex,
+    tileIndex);
+  return {
+    furos: makeRed
+      ? toggled.map((furo, fi) => {
+        return fi === furoIndex
+          ? furo
+          : {
+              ...furo,
+              tiles: clearRedFivesOfSuit(furo.tiles,
+                target.suit),
+            };
+      })
+      : toggled,
+    hand: makeRed
+      ? clearRedFivesOfSuit(hand,
+        target.suit)
+      : [
+          ...hand
+        ],
+  };
 };


### PR DESCRIPTION
## 概要

赤ドラ（赤5）の「同色1枚まで」を、手牌と全副露を**横断**して保証する（#37）。これまでは手牌内・各副露内でしか効かず、手牌＋副露や副露同士で同色赤5を重複指定でき赤ドラが過剰計上され得た。

## 変更内容

- `toggleHandRedFive(hand, furos, index)` / `toggleFuroRedFive(hand, furos, furoIndex, tileIndex)` を追加。手牌と副露の両方を受け取り両方返す純粋関数で、赤にする際は**同色の赤5を他の場所（手牌・他の副露）からも解除**する。
- `clearRedFivesOfSuit` を追加。App の赤トグルハンドラ（手牌・副露）をこれらに差し替え。
- 横断ガードの単体テストを追加（手牌→副露解除 / 副露→手牌解除 / 副露→別副露解除）。

## 確認

- `yarn lint` / `yarn test`（97）/ `yarn build` パス。

Closes #37